### PR TITLE
update URLs to point to GitHub instead of fedorahosted.org

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -91,7 +91,7 @@ setup(
     author='Radek Novacek',
     author_email='rnovacek@redhat.com',
     license='LICENSE',
-    url='https://fedorahosted.org/virt-who/',
+    url='https://github.com/virt-who/virt-who',
     packages=find_packages(),
     entry_points={
         'console_scripts': [

--- a/virt-who.spec
+++ b/virt-who.spec
@@ -11,7 +11,7 @@ Summary:        Agent for reporting virtual guest IDs to subscription-manager
 
 Group:          System Environment/Base
 License:        GPLv2+
-URL:            https://fedorahosted.org/virt-who/
+URL:            https://github.com/virt-who/virt-who
 Source0:        https://fedorahosted.org/releases/v/i/virt-who/%{name}-%{version}.tar.gz
 BuildRoot:      %(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
 

--- a/virtwho/virt/vdsm/vdsm.py
+++ b/virtwho/virt/vdsm/vdsm.py
@@ -2,7 +2,7 @@
 Module for accessing vdsm, part of virt-who
 
 Parts of this file is based on rhn-virtualization from spacewalk
-http://git.fedorahosted.org/git/?p=spacewalk.git;a=tree;f=client/tools/rhn-virtualization
+https://github.com/spacewalkproject/spacewalk/tree/master/client/tools/rhn-virtualization
 
 Copyright (C) 2011 Radek Novacek <rnovacek@redhat.com>
 


### PR DESCRIPTION
fedorahosted.org is no more