### PR TITLE
python-argparse is required for Python 2.6 on EL6

### DIFF
--- a/virt-who.spec
+++ b/virt-who.spec
@@ -27,6 +27,8 @@ Requires:       python-suds
 # m2crypto is required for Hyper-V support
 Requires:       m2crypto
 Requires:       python-requests
+# python-argparse is required for Python 2.6 on EL6
+%{?el6:Requires: python-argparse}
 
 %if %{use_systemd}
 Requires: systemd-python


### PR DESCRIPTION
otherwise `virt-who` does not start on EL6:

```
[root@rhel6 ~]# service virt-who start
Starting virt-who: Traceback (most recent call last):
  File "/usr/bin/virt-who", line 9, in <module>
    load_entry_point('virt-who==0.20.2', 'console_scripts', 'virt-who')()
  File "/usr/lib/python2.6/site-packages/pkg_resources.py", line 299, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
  File "/usr/lib/python2.6/site-packages/pkg_resources.py", line 2229, in load_entry_point
    return ep.load()
  File "/usr/lib/python2.6/site-packages/pkg_resources.py", line 1948, in load
    entry = __import__(self.module_name, globals(),globals(), ['__name__'])
  File "/usr/lib/python2.6/site-packages/virtwho/__main__.py", line 6, in <module>
    import virtwho.main
  File "/usr/lib/python2.6/site-packages/virtwho/main.py", line 38, in <module>
    from virtwho.parser import parse_options, OptionError
  File "/usr/lib/python2.6/site-packages/virtwho/parser.py", line 25, in <module>
    from argparse import ArgumentParser, Action
ImportError: No module named argparse
                                                           [FAILED]
```