### PR TITLE
Begin use of EffectiveConfig Sections in creation of virt backends

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -30,12 +30,13 @@ import random
 
 from base import TestBase, unittest
 
-from virtwho.config import ConfigManager, InvalidOption, GeneralConfig, \
-    NotSetSentinel, GlobalConfig, parse_list, Satellite6DestinationInfo
+from virtwho.config import DestinationToSourceMapper, InvalidOption, GeneralConfig, \
+    NotSetSentinel, GlobalConfig, parse_list, Satellite6DestinationInfo, init_config, \
+    EffectiveConfig, reset_effective_config, VW_GLOBAL, VW_ENV_CLI_SECTION_NAME
 from virtwho.password import Password, InvalidKeyFile
 
 default_config_values = {
-    "name":"test",
+    "name": "test",
     "type": "esx",
     "server": "1.2.3.4",
     "username": "admin",
@@ -116,6 +117,9 @@ class TestReadingConfigs(TestBase):
         self.addCleanup(shutil.rmtree, self.config_dir)
         self.logger = logging.getLogger("virtwho.main")
 
+    def tearDown(self):
+        reset_effective_config()
+
     @staticmethod
     def dict_to_ini(in_dict):
         """
@@ -134,53 +138,51 @@ class TestReadingConfigs(TestBase):
                           in_dict.iteritems() if key is not "name"])
         return header + body + "\n"
 
-    def testEmptyConfig(self):
-        manager = ConfigManager(self.logger, self.config_dir)
-        self.assertEqual(len(manager.configs), 0)
+    def test_empty_config(self):
+        config = init_config({}, {}, self.config_dir)
+        self.assertItemsEqual(config.keys(), [VW_GLOBAL, VW_ENV_CLI_SECTION_NAME])
 
-    def assertConfigEqualsDefault(self, config):
+    def assert_config_equals_default(self, config):
         self.assertEqual(config.name, "test")
-        self.assertEqual(config.type, "esx")
-        self.assertEqual(config.server, "1.2.3.4")
-        self.assertEqual(config.username, "admin")
-        self.assertEqual(config.password, "password")
-        self.assertEqual(config.owner, "root")
-        self.assertEqual(config.env, "staging")
-        self.assertEqual(config.rhsm_username, 'admin')
-        self.assertEqual(config.rhsm_password, 'password')
-        self.assertEqual(config.rhsm_hostname, 'host')
-        self.assertEqual(config.rhsm_port, '1234')
-        self.assertEqual(config.rhsm_prefix, 'prefix')
-        self.assertEqual(config.rhsm_proxy_hostname, 'proxy host')
-        self.assertEqual(config.rhsm_proxy_port, '4321')
-        self.assertEqual(config.rhsm_proxy_user, 'proxyuser')
-        self.assertEqual(config.rhsm_proxy_password, 'proxypass')
-        self.assertEqual(config.rhsm_insecure, '1')
-        self.assertEqual(config.simplified_vim, True)
+        self.assertEqual(config['type'], "esx")
+        self.assertEqual(config['server'], "1.2.3.4")
+        self.assertEqual(config['username'], "admin")
+        self.assertEqual(config['password'], "password")
+        self.assertEqual(config['owner'], "root")
+        self.assertEqual(config['env'], "staging")
+        self.assertEqual(config['rhsm_username'], 'admin')
+        self.assertEqual(config['rhsm_password'], 'password')
+        self.assertEqual(config['rhsm_hostname'], 'host')
+        self.assertEqual(config['rhsm_port'], '1234')
+        self.assertEqual(config['rhsm_prefix'], 'prefix')
+        self.assertEqual(config['rhsm_proxy_hostname'], 'proxy host')
+        self.assertEqual(config['rhsm_proxy_port'], '4321')
+        self.assertEqual(config['rhsm_proxy_user'], 'proxyuser')
+        self.assertEqual(config['rhsm_proxy_password'], 'proxypass')
+        self.assertEqual(config['rhsm_insecure'], '1')
+        self.assertEqual(config['simplified_vim'], True)
 
     def assert_config_contains_all(self, config, options):
         for key in options:
             config_value = getattr(config, key)
             self.assertEquals(config_value, options[key])
 
-    def testBasicConfig(self):
+    def test_basic_config(self):
         with open(os.path.join(self.config_dir, "test.conf"), "w") as f:
             f.write(TestReadingConfigs.dict_to_ini(default_config_values))
+        config = init_config({}, {}, config_dir=self.config_dir)
+        self.assertItemsEqual(config.keys(), ['test'])
+        self.assert_config_equals_default(config['test'])
 
-        manager = ConfigManager(self.logger, self.config_dir)
-        self.assertEqual(len(manager.configs), 1)
-        config = manager.configs[0]
-        self.assertConfigEqualsDefault(config)
-
-    def testInvalidConfig(self):
+    def test_invalid_config(self):
         with open(os.path.join(self.config_dir, "test.conf"), "w") as f:
             f.write("""
 Malformed configuration file
 """)
-        manager = ConfigManager(self.logger, self.config_dir)
+        manager = DestinationToSourceMapper(init_config({}, {}, config_dir=self.config_dir))
         self.assertEqual(len(manager.configs), 0)
 
-    def testInvalidType(self):
+    def test_invalid_type(self):
         filename = os.path.join(self.config_dir, "test.conf")
         with open(filename, "w") as f:
             f.write("""
@@ -189,16 +191,16 @@ type=invalid
 server=1.2.3.4
 username=test
 """)
-        # Instantiating the ConfigManager with an invalid config should not fail
-        # instead we expect that the list of configs managed by the ConfigManager does not
+        # Instantiating the DestinationToSourceMapper with an invalid config should not fail
+        # instead we expect that the list of configs managed by the DestinationToSourceMapper does not
         # include the invalid one
-        config_manager = ConfigManager(self.logger, self.config_dir)
+        config_manager = DestinationToSourceMapper(init_config({}, {}, config_dir=self.config_dir))
         # There should be no configs parsed successfully, therefore the list of configs should
         # be empty
         self.assertEqual(len(config_manager.configs), 0)
 
     @unittest.skipIf(os.getuid() == 0, "Can't create unreadable file when running as root")
-    def testUnreadableConfig(self):
+    def test_unreadable_config(self):
         filename = os.path.join(self.config_dir, "test.conf")
         with open(filename, "w") as f:
             f.write("""
@@ -211,7 +213,7 @@ owner=root
 env=staging
 """)
         os.chmod(filename, 0)
-        manager = ConfigManager(self.logger, self.config_dir)
+        manager = DestinationToSourceMapper(init_config({}, {}, config_dir=self.config_dir))
         self.assertEqual(len(manager.configs), 0)
 
     @patch('virtwho.password.Password._read_key_iv')
@@ -231,9 +233,9 @@ encrypted_password=%s
 owner=root
 env=staging
 """ % crypted)
-        manager = ConfigManager(self.logger, self.config_dir)
+        manager = DestinationToSourceMapper(init_config({}, {}, config_dir=self.config_dir))
         self.assertEqual(len(manager.configs), 1)
-        self.assertEqual(manager.configs[0].password, passwd)
+        self.assertEqual(manager.configs[0][1]['password'], passwd)
 
     @patch('virtwho.password.Password._read_key_iv')
     def testCryptedRHSMPassword(self, password):
@@ -254,9 +256,9 @@ rhsm_encrypted_password=%s
 owner=root
 env=staging
 """ % crypted)
-        manager = ConfigManager(self.logger, self.config_dir)
+        manager = DestinationToSourceMapper(init_config({}, {}, config_dir=self.config_dir))
         self.assertEqual(len(manager.configs), 1)
-        self.assertEqual(manager.configs[0].rhsm_password, passwd)
+        self.assertEqual(manager.configs[0][1]["rhsm_password"], passwd)
 
     @patch('virtwho.password.Password._read_key_iv')
     def testCryptedRHSMProxyPassword(self, password):
@@ -276,9 +278,9 @@ rhsm_encrypted_proxy_password=%s
 owner=root
 env=staging
 """ % crypted)
-        manager = ConfigManager(self.logger, self.config_dir)
+        manager = DestinationToSourceMapper(init_config({}, {}, config_dir=self.config_dir))
         self.assertEqual(len(manager.configs), 1)
-        self.assertEqual(manager.configs[0].rhsm_proxy_password, passwd)
+        self.assertEqual(manager.configs[0][1]["rhsm_proxy_password"], passwd)
 
     def testCryptedPasswordWithoutKey(self):
         Password.KEYFILE = "/some/nonexistant/file"
@@ -292,10 +294,10 @@ env=staging
 [test]
 type=esx
 """)
-        # Instantiating the ConfigManager with an invalid config should not fail
-        # instead we expect that the list of configs managed by the ConfigManager does not
+        # Instantiating the DestinationToSourceMapper with an invalid config should not fail
+        # instead we expect that the list of configs managed by the DestinationToSourceMapper does not
         # include the invalid one
-        config_manager = ConfigManager(self.logger, self.config_dir)
+        config_manager = DestinationToSourceMapper(init_config({}, {}, config_dir=self.config_dir))
         # There should be no configs parsed successfully, therefore the list of configs should
         # be empty
         self.assertEqual(len(config_manager.configs), 0)
@@ -310,7 +312,7 @@ type=esx
             f.write(TestReadingConfigs.dict_to_ini(config_1) +
                     TestReadingConfigs.dict_to_ini(config_2))
 
-        manager = ConfigManager(self.logger, self.config_dir)
+        manager = DestinationToSourceMapper(init_config({}, {}, config_dir=self.config_dir))
         self.assertEqual(len(manager.configs), 2)
         config = manager.configs[0]
         self.assert_config_contains_all(config, config_1)
@@ -338,7 +340,7 @@ type=esx
             expected_dest_2: [config_2['name']]
         }
 
-        manager = ConfigManager(self.logger, self.config_dir)
+        manager = DestinationToSourceMapper(init_config({}, {}, config_dir=self.config_dir))
         self.assertEqual(len(manager.configs), 2)
         self.assertEqual(manager.dest_to_sources_map, expected_mapping)
         self.assertEqual(manager.dests, set([expected_dest_1, expected_dest_2]))
@@ -371,7 +373,7 @@ type=esx
             f.write(TestReadingConfigs.dict_to_ini(config_1) +
                     TestReadingConfigs.dict_to_ini(config_2))
 
-        manager = ConfigManager(self.logger, self.config_dir)
+        manager = DestinationToSourceMapper(init_config({}, {}, config_dir=self.config_dir))
         self.assertEqual(manager.dests, set([expected_dest]))
         self.assertEqual(manager.sources,
                          set([config_1['name'], config_2['name']]))
@@ -408,7 +410,7 @@ type=esx
             f.write(TestReadingConfigs.dict_to_ini(config_1) +
                     TestReadingConfigs.dict_to_ini(config_2))
 
-        manager = ConfigManager(self.logger, self.config_dir)
+        manager = DestinationToSourceMapper(init_config({}, {}, config_dir=self.config_dir))
         self.assertEquals(manager.dest_to_sources_map, expected_mapping)
 
     def test_one_source_to_one_dest(self):
@@ -423,7 +425,7 @@ type=esx
         with open(os.path.join(self.config_dir, "test1.conf"), "w") as f:
             f.write(TestReadingConfigs.dict_to_ini(config_1))
 
-        manager = ConfigManager(self.logger, self.config_dir)
+        manager = DestinationToSourceMapper(init_config({}, {}, config_dir=self.config_dir))
         self.assertEquals(manager.dest_to_sources_map, expected_mapping)
 
     def test_two_sources_to_two_dests(self):
@@ -444,7 +446,7 @@ type=esx
             f.write(TestReadingConfigs.dict_to_ini(config_1) +
                     TestReadingConfigs.dict_to_ini(config_2))
 
-        manager = ConfigManager(self.logger, self.config_dir)
+        manager = DestinationToSourceMapper(init_config({}, {}, config_dir=self.config_dir))
         self.assertEquals(manager.dest_to_sources_map, expected_mapping)
 
     def test_many_sources_to_many_dests(self):
@@ -487,7 +489,7 @@ type=esx
                     TestReadingConfigs.dict_to_ini(config_3) +
                     TestReadingConfigs.dict_to_ini(config_4))
 
-        manager = ConfigManager(self.logger, self.config_dir)
+        manager = DestinationToSourceMapper(init_config({}, {}, config_dir=self.config_dir))
         self.assertEquals(manager.dest_to_sources_map, expected_mapping)
 
     def testLibvirtConfig(self):
@@ -501,7 +503,7 @@ password=password
 owner=root
 env=staging
 """)
-        manager = ConfigManager(self.logger, self.config_dir)
+        manager = DestinationToSourceMapper(init_config({}, {}, config_dir=self.config_dir))
         self.assertEqual(len(manager.configs), 1)
         config = manager.configs[0]
         self.assertEqual(config.name, "test1")
@@ -524,7 +526,7 @@ owner=root
 env=staging
 simplified_vim=false
 """)
-        manager = ConfigManager(self.logger, self.config_dir)
+        manager = DestinationToSourceMapper(init_config({}, {}, config_dir=self.config_dir))
         self.assertEqual(len(manager.configs), 1)
         config = manager.configs[0]
         self.assertFalse(config.simplified_vim)
@@ -540,10 +542,10 @@ password=password
 owner=root
 rhsm_hostname=abc
 """)
-        # Instantiating the ConfigManager with an invalid config should not fail
-        # instead we expect that the list of configs managed by the ConfigManager does not
+        # Instantiating the DestinationToSourceMapper with an invalid config should not fail
+        # instead we expect that the list of configs managed by the DestinationToSourceMapper does not
         # include the invalid one
-        config_manager = ConfigManager(self.logger, self.config_dir)
+        config_manager = DestinationToSourceMapper(init_config({}, {}, config_dir=self.config_dir))
         # There should be no configs parsed successfully, therefore the list of configs should
         # be empty
         self.assertEqual(len(config_manager.configs), 0)
@@ -559,10 +561,10 @@ password=password
 env=env
 rhsm_hostname=abc
 """)
-        # Instantiating the ConfigManager with an invalid config should not fail
-        # instead we expect that the list of configs managed by the ConfigManager does not
+        # Instantiating the DestinationToSourceMapper with an invalid config should not fail
+        # instead we expect that the list of configs managed by the DestinationToSourceMapper does not
         # include the invalid one
-        config_manager = ConfigManager(self.logger, self.config_dir)
+        config_manager = DestinationToSourceMapper(init_config({}, {}, config_dir=self.config_dir))
         # There should be no configs parsed successfully, therefore the list of configs should
         # be empty
         self.assertEqual(len(config_manager.configs), 0)
@@ -588,10 +590,10 @@ password=password
 env=env
 rhsm_hostname=abc
 """ % {'valid_config_name': valid_config_name})
-        config_manager = ConfigManager(self.logger, self.config_dir)
+        config_manager = DestinationToSourceMapper(init_config({}, {}, config_dir=self.config_dir))
         # There should be only one config, and that should be the one that is valid
         self.assertEqual(len(config_manager.configs), 1)
-        self.assertEquals(config_manager.configs[0].name, valid_config_name)
+        self.assertEquals(config_manager.configs[0][1]["name"], valid_config_name)
 
     def testInvisibleConfigFile(self):
         with open(os.path.join(self.config_dir, ".test1.conf"), "w") as f:
@@ -604,7 +606,7 @@ password=password
 owner=root
 env=staging
 """)
-        manager = ConfigManager(self.logger, self.config_dir)
+        manager = DestinationToSourceMapper(init_config({}, {}, config_dir=self.config_dir))
         self.assertEqual(len(manager.configs), 0, "Hidden config file shouldn't be read")
 
     def testFilterHostOld(self):
@@ -619,9 +621,9 @@ owner=root
 env=staging
 filter_host_uuids=12345
 """)
-        manager = ConfigManager(self.logger, self.config_dir)
+        manager = DestinationToSourceMapper(init_config({}, {}, config_dir=self.config_dir))
         self.assertEqual(len(manager.configs), 1)
-        self.assertEqual(manager.configs[0].filter_hosts, ['12345'])
+        self.assertEqual(manager.configs[0][1]["filter_hosts"], ['12345'])
 
     def testFilterHostNew(self):
         with open(os.path.join(self.config_dir, "test1.conf"), "w") as f:
@@ -635,9 +637,9 @@ owner=root
 env=staging
 filter_hosts=12345
 """)
-        manager = ConfigManager(self.logger, self.config_dir)
+        manager = DestinationToSourceMapper(init_config({}, {}, config_dir=self.config_dir))
         self.assertEqual(len(manager.configs), 1)
-        self.assertEqual(manager.configs[0].filter_hosts, ['12345'])
+        self.assertEqual(manager.configs[0][1]["filter_hosts"], ['12345'])
 
     def testQuotesInConfig(self):
         with open(os.path.join(self.config_dir, "test1.conf"), "w") as f:
@@ -650,7 +652,7 @@ password=p"asswor'd
 owner=" root "
 env='"staging"'
 """)
-        manager = ConfigManager(self.logger, self.config_dir)
+        manager = DestinationToSourceMapper(init_config({}, {}, config_dir=self.config_dir))
         self.assertEqual(len(manager.configs), 1)
         config = manager.configs[0]
         self.assertEqual(config.name, "test1")
@@ -672,7 +674,7 @@ password=password
 owner=здравствуйте
 env=العَرَبِيَّة
 """)
-        manager = ConfigManager(self.logger, self.config_dir)
+        manager = DestinationToSourceMapper(init_config({}, {}, config_dir=self.config_dir))
         self.assertEqual(len(manager.configs), 1)
         config = manager.configs[0]
         self.assertEqual(config.name, "test1")
@@ -726,27 +728,27 @@ rhsm_proxy_password=proxypass2
 rhsm_insecure=2
 """)
 
-        manager = ConfigManager(self.logger, self.config_dir)
+        manager = DestinationToSourceMapper(init_config({}, {}, config_dir=self.config_dir))
         self.assertEqual(len(manager.configs), 1)
-        config = manager.configs[0]
+        name, config = manager.configs[0]
 
-        self.assertEqual(config.name, "test1")
-        self.assertEqual(config.type, "esx")
-        self.assertEqual(config.server, "1.2.3.4")
-        self.assertEqual(config.username, "admin")
-        self.assertEqual(config.password, "password")
-        self.assertEqual(config.owner, "root")
-        self.assertEqual(config.env, "staging")
-        self.assertEqual(config.rhsm_username, 'rhsm_admin1')
-        self.assertEqual(config.rhsm_password, 'rhsm_password1')
-        self.assertEqual(config.rhsm_hostname, 'host1')
-        self.assertEqual(config.rhsm_port, '12341')
-        self.assertEqual(config.rhsm_prefix, 'prefix1')
-        self.assertEqual(config.rhsm_proxy_hostname, 'proxyhost1')
-        self.assertEqual(config.rhsm_proxy_port, '43211')
-        self.assertEqual(config.rhsm_proxy_user, 'proxyuser1')
-        self.assertEqual(config.rhsm_proxy_password, 'proxypass1')
-        self.assertEqual(config.rhsm_insecure, '1')
+        self.assertEqual(name, "test1")
+        self.assertEqual(config["type"], "esx")
+        self.assertEqual(config["server"], "1.2.3.4")
+        self.assertEqual(config["username"], "admin")
+        self.assertEqual(config["password"], "password")
+        self.assertEqual(config["owner"], "root")
+        self.assertEqual(config["env"], "staging")
+        self.assertEqual(config["rhsm_username"], 'rhsm_admin1')
+        self.assertEqual(config["rhsm_password"], 'rhsm_password1')
+        self.assertEqual(config["rhsm_hostname"], 'host1')
+        self.assertEqual(config["rhsm_port"], '12341')
+        self.assertEqual(config["rhsm_prefix"], 'prefix1')
+        self.assertEqual(config["rhsm_proxy_hostname"], 'proxyhost1')
+        self.assertEqual(config["rhsm_proxy_port"], '43211')
+        self.assertEqual(config["rhsm_proxy_user"], 'proxyuser1')
+        self.assertEqual(config["rhsm_proxy_password"], 'proxypass1')
+        self.assertEqual(config["rhsm_insecure"], '1')
 
 
 class TestGeneralConfig(TestBase):

--- a/tests/test_fake.py
+++ b/tests/test_fake.py
@@ -25,7 +25,7 @@ import shutil
 
 from base import TestBase
 
-from virtwho.config import ConfigManager
+from virtwho.config import DestinationToSourceMapper
 from virtwho.virt import Virt, Hypervisor, VirtError
 from virtwho.virt.fakevirt import FakeVirt
 
@@ -89,7 +89,7 @@ is_hypervisor=true
 file=%s
 """ % self.hypervisor_file)
 
-        manager = ConfigManager(self.logger, self.config_dir)
+        manager = DestinationToSourceMapper(self.logger, self.config_dir)
         self.assertEquals(len(manager.configs), 1)
         virt = Virt.from_config(self.logger, manager.configs[0], None)
         self.assertEquals(type(virt), FakeVirt)
@@ -117,7 +117,7 @@ is_hypervisor=true
 file=%s
 """ % self.hypervisor_file)
 
-        manager = ConfigManager(self.logger, self.config_dir)
+        manager = DestinationToSourceMapper(self.logger, self.config_dir)
         self.assertEquals(len(manager.configs), 1)
         virt = Virt.from_config(self.logger, manager.configs[0], None)
         self.assertEquals(type(virt), FakeVirt)
@@ -135,7 +135,7 @@ is_hypervisor=false
 file=%s
 """ % self.hypervisor_file)
 
-        manager = ConfigManager(self.logger, self.config_dir)
+        manager = DestinationToSourceMapper(self.logger, self.config_dir)
         self.assertEquals(len(manager.configs), 1)
         virt = Virt.from_config(self.logger, manager.configs[0], None)
         self.assertEquals(type(virt), FakeVirt)
@@ -157,7 +157,7 @@ is_hypervisor=false
 file=%s
 """ % self.hypervisor_file)
 
-        manager = ConfigManager(self.logger, self.config_dir)
+        manager = DestinationToSourceMapper(self.logger, self.config_dir)
         self.assertEquals(len(manager.configs), 1)
         virt = Virt.from_config(self.logger, manager.configs[0], None)
         self.assertEquals(type(virt), FakeVirt)

--- a/tests/test_satellite.py
+++ b/tests/test_satellite.py
@@ -31,7 +31,7 @@ from mock import MagicMock, patch
 
 from base import TestBase
 
-from virtwho.config import Config, ConfigManager, VW_ENV_CLI_SECTION_NAME
+from virtwho.config import Config, DestinationToSourceMapper, VW_ENV_CLI_SECTION_NAME
 from virtwho.manager import Manager
 from virtwho.manager.satellite import Satellite, SatelliteError
 from virtwho.virt import Guest, Hypervisor, HostGuestAssociationReport
@@ -354,7 +354,7 @@ type=libvirt
 sat_server=sat.example.com
 """)
 
-        config_manager = ConfigManager(self.logger, config_dir)
+        config_manager = DestinationToSourceMapper(self.logger, config_dir)
         self.assertEqual(len(config_manager.configs), 1)
         config = config_manager.configs[0]
         manager = Manager.fromOptions(self.logger, MagicMock(), config)

--- a/tests/test_subscriptionmanager.py
+++ b/tests/test_subscriptionmanager.py
@@ -7,7 +7,7 @@ from mock import patch, Mock, DEFAULT, MagicMock, ANY
 
 from base import TestBase, unittest
 
-from virtwho.config import Config, ConfigManager, VW_ENV_CLI_SECTION_NAME
+from virtwho.config import Config, DestinationToSourceMapper, VW_ENV_CLI_SECTION_NAME
 from virtwho.manager import Manager
 from virtwho.manager.subscriptionmanager import SubscriptionManager
 from virtwho.virt import Guest, Hypervisor, HostGuestAssociationReport, DomainListReport, AbstractVirtReport
@@ -171,7 +171,7 @@ rhsm_username=user
 rhsm_password=passwd
 """)
 
-        config_manager = ConfigManager(self.logger, config_dir)
+        config_manager = DestinationToSourceMapper(self.logger, config_dir)
         self.assertEqual(len(config_manager.configs), 1)
         config = config_manager.configs[0]
         manager = Manager.fromOptions(self.logger, Mock(), config)
@@ -230,7 +230,7 @@ rhsm_username=user
 rhsm_password=passwd
 """)
 
-        config_manager = ConfigManager(self.logger, config_dir)
+        config_manager = DestinationToSourceMapper(self.logger, config_dir)
         self.assertEqual(len(config_manager.configs), 1)
         config = config_manager.configs[0]
         manager = Manager.fromOptions(self.logger, Mock(), config)

--- a/tests/test_virt.py
+++ b/tests/test_virt.py
@@ -9,7 +9,7 @@ from stubs import StubEffectiveConfig
 from mock import Mock, patch, call
 from threading import Event
 
-from virtwho.config import ConfigManager, Config, VW_GLOBAL
+from virtwho.config import DestinationToSourceMapper, Config, VW_GLOBAL
 from virtwho.manager import ManagerThrottleError, ManagerFatalError
 from virtwho.virt import HostGuestAssociationReport, Hypervisor, Guest, \
     DestinationThread, ErrorReport, AbstractVirtReport, DomainListReport
@@ -65,7 +65,7 @@ owner=owner
 env=env
 {config}
 """.format(config=config))
-        config_manager = ConfigManager(self.logger, config_dir)
+        config_manager = DestinationToSourceMapper(self.logger, config_dir)
         self.assertEqual(len(config_manager.configs), 1)
         config = config_manager.configs[0]
 

--- a/tests/test_virtwho.py
+++ b/tests/test_virtwho.py
@@ -27,7 +27,7 @@ from mock import patch, Mock, sentinel, ANY, call
 from base import TestBase
 
 from virtwho import util
-from virtwho.config import Config, ConfigManager, VW_GLOBAL, VW_ENV_CLI_SECTION_NAME
+from virtwho.config import Config, DestinationToSourceMapper, VW_GLOBAL, VW_ENV_CLI_SECTION_NAME
 from virtwho.manager import ManagerThrottleError, ManagerFatalError
 from virtwho.virt import (
     HostGuestAssociationReport, Hypervisor, Guest,

--- a/virtwho/executor.py
+++ b/virtwho/executor.py
@@ -4,7 +4,7 @@ import sys
 
 from virtwho import log
 
-from virtwho.config import ConfigManager, VW_GLOBAL
+from virtwho.config import DestinationToSourceMapper, VW_GLOBAL
 from virtwho.datastore import Datastore
 from virtwho.manager import Manager
 from virtwho.virt import Virt, info_to_destination_class
@@ -21,7 +21,7 @@ class ReloadRequest(Exception):
 
 
 class Executor(object):
-    def __init__(self, logger, options, config_dir=None):
+    def __init__(self, logger, options):
         """
         Executor class provides bridge between virtualization supervisor and
         Subscription Manager.
@@ -39,17 +39,17 @@ class Executor(object):
         self.datastore = Datastore()
         self.reloading = False
 
-        self.configManager = ConfigManager(self.logger, config_dir)
+        self.dest_to_source_mapper = DestinationToSourceMapper(options)
 
-        for config in self.configManager.configs:
-            logger.debug("Using config named '%s'" % config.name)
+        for name, config in self.dest_to_source_mapper.configs:
+            logger.debug("Using config named '%s'" % name)
 
     def _create_virt_backends(self):
         """
         Create virts list with virt backend threads
         """
         virts = []
-        for config in self.configManager.configs:
+        for name, config in self.dest_to_source_mapper.configs:
             try:
                 logger = log.getLogger(config=config)
                 virt = Virt.from_config(logger, config, self.datastore,
@@ -57,7 +57,7 @@ class Executor(object):
                                         interval=self.options[VW_GLOBAL]['interval'],
                                         oneshot=self.options[VW_GLOBAL]['oneshot'])
             except Exception as e:
-                self.logger.error('Unable to use configuration "%s": %s', config.name, str(e))
+                self.logger.error('Unable to use configuration "%s": %s', name, str(e))
                 continue
             virts.append(virt)
         return virts
@@ -70,11 +70,11 @@ class Executor(object):
             @type: bool
         """
         dests = []
-        for info in self.configManager.dests:
+        for info in self.dest_to_source_mapper.dests:
             # Dests should already include all destinations we want created
             # at this time. This method will make no assumptions of creating
             # defaults of any kind.
-            source_keys = self.configManager.dest_to_sources_map[info]
+            source_keys = self.dest_to_source_mapper.dest_to_sources_map[info]
             info.name = "destination_%s" % hash(info)
             logger = log.getLogger(name=info.name)
             manager = Manager.fromInfo(logger, self.options, info)
@@ -160,7 +160,7 @@ class Executor(object):
 
         if self.options[VW_GLOBAL]['print']:
             to_print = {}
-            for source in self.configManager.sources:
+            for source in self.dest_to_source_mapper.sources:
                 try:
                     report = self.datastore.get(source)
                     config = report.config
@@ -179,11 +179,11 @@ class Executor(object):
         self.logger.debug("Starting infinite loop with %d seconds interval",
                           self.options[VW_GLOBAL]['interval'])
 
-        # Need to update the dest to source mapping of the configManager object
+        # Need to update the dest to source mapping of the dest_to_source_mapper object
         # here because of the way that main reads the config from the command
         # line
         # TODO: Update dests to source map on addition or removal of configs
-        self.configManager.update_dest_to_source_map()
+        self.dest_to_source_mapper.update_dest_to_source_map()
         # Start all sources
         self.virts = self._create_virt_backends()
 

--- a/virtwho/virt/virt.py
+++ b/virtwho/virt/virt.py
@@ -297,7 +297,7 @@ class IntervalThread(Thread):
         self.dest = dest
         self._internal_terminate_event = Event()
         self.terminate_event = terminate_event or self._internal_terminate_event
-        self.interval = interval or config.interval or DefaultInterval
+        self.interval = interval
         self._oneshot = oneshot
         super(IntervalThread, self).__init__()
 
@@ -867,7 +867,7 @@ class Virt(IntervalThread):
         """
 
         for subcls in cls.__subclasses_list():
-            if config.type == subcls.CONFIG_TYPE:
+            if config['type'] == subcls.CONFIG_TYPE:
                 return subcls(logger, config, dest,
                               terminate_event=terminate_event,
                               interval=interval, oneshot=oneshot)


### PR DESCRIPTION
This PR finishes laying the ground work for using the new ConfigSections to create virt backends.

Please note: As there are no backend specific ConfigSections yet (especially including any that handle encrypted password bits) there are a number of tests which do not pass and will not pass.

I fully expect all tests to pass when the config_refactor branch is merged to master but for this step I think it's necessary for them not to (in order to keep the PRs at least somewhat small).

For testing purposes I expect the libvirt backend to work as expected in all forms of configuration. I've added a temporary commit to modify the libvirt backend to work with a generic config section. Encrypted passwords will still not work with the libvirt backend.