### PR TITLE
Implemented ConfigSection subclass for virtual backends

### DIFF
--- a/tests/complex/virtwhotest.py
+++ b/tests/complex/virtwhotest.py
@@ -64,9 +64,8 @@ class TestBase(TestCase):
         virt-who process (or None if `background` is True) and stdout is
         stdout from the process (or None if `grab_stdout` is False).
         '''
-        oldMinimumSendInterval = virtwho.executor.MinimumSendInterval
-        virtwho.executor.MinimumSendInterval = 2
-        virtwho.parser.MinimumSendInterval = 2
+        old_minimum_send_interval = virtwho.config.MinimumSendInterval
+        virtwho.config.MinimumSendInterval = 2
         virtwho.log.Logger._stream_handler = None
         virtwho.log.Logger._queue_logger = None
         old_stdout = None
@@ -90,8 +89,8 @@ class TestBase(TestCase):
             sys.stdout.close()
             sys.stdout = old_stdout
 
-        virtwho.executor.MinimumSendInterval = oldMinimumSendInterval
-        virtwho.parser.MinimumSendInterval = oldMinimumSendInterval
+        virtwho.config.MinimumSendInterval = old_minimum_send_interval
+
         return code, data
 
     def stop_virtwho(self):

--- a/tests/stubs.py
+++ b/tests/stubs.py
@@ -1,0 +1,31 @@
+"""
+Module including Stubs of various objects for use during testing
+
+Copyright (C) 2017 Christopher Snyder <csnyder@redhat.com>
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+"""
+
+
+class StubEffectiveConfig(object):
+
+    def __init__(self, values):
+        self.values = values
+
+    def __getitem__(self, key):
+        return self.values[key]
+
+    def get(self, section):
+        return self.values[section]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -32,7 +32,7 @@ from base import TestBase, unittest
 
 from virtwho.config import DestinationToSourceMapper, InvalidOption, GeneralConfig, \
     NotSetSentinel, GlobalConfig, parse_list, Satellite6DestinationInfo, init_config, \
-    EffectiveConfig, reset_effective_config, VW_GLOBAL, VW_ENV_CLI_SECTION_NAME
+    EffectiveConfig, VW_GLOBAL, VW_ENV_CLI_SECTION_NAME
 from virtwho.password import Password, InvalidKeyFile
 
 default_config_values = {

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -30,12 +30,13 @@ import random
 
 from base import TestBase, unittest
 
-from virtwho.config import ConfigManager, InvalidOption, GeneralConfig, \
-    NotSetSentinel, GlobalConfig, parse_list, Satellite6DestinationInfo
+from virtwho.config import DestinationToSourceMapper, InvalidOption, GeneralConfig, \
+    NotSetSentinel, GlobalConfig, parse_list, Satellite6DestinationInfo, init_config, \
+    EffectiveConfig, reset_effective_config, VW_GLOBAL, VW_ENV_CLI_SECTION_NAME
 from virtwho.password import Password, InvalidKeyFile
 
 default_config_values = {
-    "name":"test",
+    "name": "test",
     "type": "esx",
     "server": "1.2.3.4",
     "username": "admin",
@@ -116,6 +117,9 @@ class TestReadingConfigs(TestBase):
         self.addCleanup(shutil.rmtree, self.config_dir)
         self.logger = logging.getLogger("virtwho.main")
 
+    def tearDown(self):
+        reset_effective_config()
+
     @staticmethod
     def dict_to_ini(in_dict):
         """
@@ -134,53 +138,51 @@ class TestReadingConfigs(TestBase):
                           in_dict.iteritems() if key is not "name"])
         return header + body + "\n"
 
-    def testEmptyConfig(self):
-        manager = ConfigManager(self.logger, self.config_dir)
-        self.assertEqual(len(manager.configs), 0)
+    def test_empty_config(self):
+        config = init_config({}, {}, self.config_dir)
+        self.assertItemsEqual(config.keys(), [VW_GLOBAL, VW_ENV_CLI_SECTION_NAME])
 
-    def assertConfigEqualsDefault(self, config):
+    def assert_config_equals_default(self, config):
         self.assertEqual(config.name, "test")
-        self.assertEqual(config.type, "esx")
-        self.assertEqual(config.server, "1.2.3.4")
-        self.assertEqual(config.username, "admin")
-        self.assertEqual(config.password, "password")
-        self.assertEqual(config.owner, "root")
-        self.assertEqual(config.env, "staging")
-        self.assertEqual(config.rhsm_username, 'admin')
-        self.assertEqual(config.rhsm_password, 'password')
-        self.assertEqual(config.rhsm_hostname, 'host')
-        self.assertEqual(config.rhsm_port, '1234')
-        self.assertEqual(config.rhsm_prefix, 'prefix')
-        self.assertEqual(config.rhsm_proxy_hostname, 'proxy host')
-        self.assertEqual(config.rhsm_proxy_port, '4321')
-        self.assertEqual(config.rhsm_proxy_user, 'proxyuser')
-        self.assertEqual(config.rhsm_proxy_password, 'proxypass')
-        self.assertEqual(config.rhsm_insecure, '1')
-        self.assertEqual(config.simplified_vim, True)
+        self.assertEqual(config['type'], "esx")
+        self.assertEqual(config['server'], "1.2.3.4")
+        self.assertEqual(config['username'], "admin")
+        self.assertEqual(config['password'], "password")
+        self.assertEqual(config['owner'], "root")
+        self.assertEqual(config['env'], "staging")
+        self.assertEqual(config['rhsm_username'], 'admin')
+        self.assertEqual(config['rhsm_password'], 'password')
+        self.assertEqual(config['rhsm_hostname'], 'host')
+        self.assertEqual(config['rhsm_port'], '1234')
+        self.assertEqual(config['rhsm_prefix'], 'prefix')
+        self.assertEqual(config['rhsm_proxy_hostname'], 'proxy host')
+        self.assertEqual(config['rhsm_proxy_port'], '4321')
+        self.assertEqual(config['rhsm_proxy_user'], 'proxyuser')
+        self.assertEqual(config['rhsm_proxy_password'], 'proxypass')
+        self.assertEqual(config['rhsm_insecure'], '1')
+        self.assertEqual(config['simplified_vim'], True)
 
     def assert_config_contains_all(self, config, options):
         for key in options:
             config_value = getattr(config, key)
             self.assertEquals(config_value, options[key])
 
-    def testBasicConfig(self):
+    def test_basic_config(self):
         with open(os.path.join(self.config_dir, "test.conf"), "w") as f:
             f.write(TestReadingConfigs.dict_to_ini(default_config_values))
+        config = init_config({}, {}, config_dir=self.config_dir)
+        self.assertItemsEqual(config.keys(), ['test'])
+        self.assert_config_equals_default(config['test'])
 
-        manager = ConfigManager(self.logger, self.config_dir)
-        self.assertEqual(len(manager.configs), 1)
-        config = manager.configs[0]
-        self.assertConfigEqualsDefault(config)
-
-    def testInvalidConfig(self):
+    def test_invalid_config(self):
         with open(os.path.join(self.config_dir, "test.conf"), "w") as f:
             f.write("""
 Malformed configuration file
 """)
-        manager = ConfigManager(self.logger, self.config_dir)
+        manager = DestinationToSourceMapper(init_config({}, {}, config_dir=self.config_dir))
         self.assertEqual(len(manager.configs), 0)
 
-    def testInvalidType(self):
+    def test_invalid_type(self):
         filename = os.path.join(self.config_dir, "test.conf")
         with open(filename, "w") as f:
             f.write("""
@@ -189,16 +191,16 @@ type=invalid
 server=1.2.3.4
 username=test
 """)
-        # Instantiating the ConfigManager with an invalid config should not fail
-        # instead we expect that the list of configs managed by the ConfigManager does not
+        # Instantiating the DestinationToSourceMapper with an invalid config should not fail
+        # instead we expect that the list of configs managed by the DestinationToSourceMapper does not
         # include the invalid one
-        config_manager = ConfigManager(self.logger, self.config_dir)
+        config_manager = DestinationToSourceMapper(init_config({}, {}, config_dir=self.config_dir))
         # There should be no configs parsed successfully, therefore the list of configs should
         # be empty
         self.assertEqual(len(config_manager.configs), 0)
 
     @unittest.skipIf(os.getuid() == 0, "Can't create unreadable file when running as root")
-    def testUnreadableConfig(self):
+    def test_unreadable_config(self):
         filename = os.path.join(self.config_dir, "test.conf")
         with open(filename, "w") as f:
             f.write("""
@@ -211,7 +213,7 @@ owner=root
 env=staging
 """)
         os.chmod(filename, 0)
-        manager = ConfigManager(self.logger, self.config_dir)
+        manager = DestinationToSourceMapper(init_config({}, {}, config_dir=self.config_dir))
         self.assertEqual(len(manager.configs), 0)
 
     @patch('virtwho.password.Password._read_key_iv')
@@ -231,9 +233,9 @@ encrypted_password=%s
 owner=root
 env=staging
 """ % crypted)
-        manager = ConfigManager(self.logger, self.config_dir)
+        manager = DestinationToSourceMapper(init_config({}, {}, config_dir=self.config_dir))
         self.assertEqual(len(manager.configs), 1)
-        self.assertEqual(manager.configs[0].password, passwd)
+        self.assertEqual(manager.configs[0][1]['password'], passwd)
 
     @patch('virtwho.password.Password._read_key_iv')
     def testCryptedRHSMPassword(self, password):
@@ -254,9 +256,9 @@ rhsm_encrypted_password=%s
 owner=root
 env=staging
 """ % crypted)
-        manager = ConfigManager(self.logger, self.config_dir)
+        manager = DestinationToSourceMapper(init_config({}, {}, config_dir=self.config_dir))
         self.assertEqual(len(manager.configs), 1)
-        self.assertEqual(manager.configs[0].rhsm_password, passwd)
+        self.assertEqual(manager.configs[0][1]["rhsm_password"], passwd)
 
     @patch('virtwho.password.Password._read_key_iv')
     def testCryptedRHSMProxyPassword(self, password):
@@ -276,9 +278,9 @@ rhsm_encrypted_proxy_password=%s
 owner=root
 env=staging
 """ % crypted)
-        manager = ConfigManager(self.logger, self.config_dir)
+        manager = DestinationToSourceMapper(init_config({}, {}, config_dir=self.config_dir))
         self.assertEqual(len(manager.configs), 1)
-        self.assertEqual(manager.configs[0].rhsm_proxy_password, passwd)
+        self.assertEqual(manager.configs[0][1]["rhsm_proxy_password"], passwd)
 
     def testCryptedPasswordWithoutKey(self):
         Password.KEYFILE = "/some/nonexistant/file"
@@ -292,10 +294,10 @@ env=staging
 [test]
 type=esx
 """)
-        # Instantiating the ConfigManager with an invalid config should not fail
-        # instead we expect that the list of configs managed by the ConfigManager does not
+        # Instantiating the DestinationToSourceMapper with an invalid config should not fail
+        # instead we expect that the list of configs managed by the DestinationToSourceMapper does not
         # include the invalid one
-        config_manager = ConfigManager(self.logger, self.config_dir)
+        config_manager = DestinationToSourceMapper(init_config({}, {}, config_dir=self.config_dir))
         # There should be no configs parsed successfully, therefore the list of configs should
         # be empty
         self.assertEqual(len(config_manager.configs), 0)
@@ -310,7 +312,7 @@ type=esx
             f.write(TestReadingConfigs.dict_to_ini(config_1) +
                     TestReadingConfigs.dict_to_ini(config_2))
 
-        manager = ConfigManager(self.logger, self.config_dir)
+        manager = DestinationToSourceMapper(init_config({}, {}, config_dir=self.config_dir))
         self.assertEqual(len(manager.configs), 2)
         config = manager.configs[0]
         self.assert_config_contains_all(config, config_1)
@@ -338,7 +340,7 @@ type=esx
             expected_dest_2: [config_2['name']]
         }
 
-        manager = ConfigManager(self.logger, self.config_dir)
+        manager = DestinationToSourceMapper(init_config({}, {}, config_dir=self.config_dir))
         self.assertEqual(len(manager.configs), 2)
         self.assertEqual(manager.dest_to_sources_map, expected_mapping)
         self.assertEqual(manager.dests, set([expected_dest_1, expected_dest_2]))
@@ -371,7 +373,7 @@ type=esx
             f.write(TestReadingConfigs.dict_to_ini(config_1) +
                     TestReadingConfigs.dict_to_ini(config_2))
 
-        manager = ConfigManager(self.logger, self.config_dir)
+        manager = DestinationToSourceMapper(init_config({}, {}, config_dir=self.config_dir))
         self.assertEqual(manager.dests, set([expected_dest]))
         self.assertEqual(manager.sources,
                          set([config_1['name'], config_2['name']]))
@@ -408,7 +410,7 @@ type=esx
             f.write(TestReadingConfigs.dict_to_ini(config_1) +
                     TestReadingConfigs.dict_to_ini(config_2))
 
-        manager = ConfigManager(self.logger, self.config_dir)
+        manager = DestinationToSourceMapper(init_config({}, {}, config_dir=self.config_dir))
         self.assertEquals(manager.dest_to_sources_map, expected_mapping)
 
     def test_one_source_to_one_dest(self):
@@ -423,7 +425,7 @@ type=esx
         with open(os.path.join(self.config_dir, "test1.conf"), "w") as f:
             f.write(TestReadingConfigs.dict_to_ini(config_1))
 
-        manager = ConfigManager(self.logger, self.config_dir)
+        manager = DestinationToSourceMapper(init_config({}, {}, config_dir=self.config_dir))
         self.assertEquals(manager.dest_to_sources_map, expected_mapping)
 
     def test_two_sources_to_two_dests(self):
@@ -444,7 +446,7 @@ type=esx
             f.write(TestReadingConfigs.dict_to_ini(config_1) +
                     TestReadingConfigs.dict_to_ini(config_2))
 
-        manager = ConfigManager(self.logger, self.config_dir)
+        manager = DestinationToSourceMapper(init_config({}, {}, config_dir=self.config_dir))
         self.assertEquals(manager.dest_to_sources_map, expected_mapping)
 
     def test_many_sources_to_many_dests(self):
@@ -487,7 +489,7 @@ type=esx
                     TestReadingConfigs.dict_to_ini(config_3) +
                     TestReadingConfigs.dict_to_ini(config_4))
 
-        manager = ConfigManager(self.logger, self.config_dir)
+        manager = DestinationToSourceMapper(init_config({}, {}, config_dir=self.config_dir))
         self.assertEquals(manager.dest_to_sources_map, expected_mapping)
 
     def testLibvirtConfig(self):
@@ -501,7 +503,7 @@ password=password
 owner=root
 env=staging
 """)
-        manager = ConfigManager(self.logger, self.config_dir)
+        manager = DestinationToSourceMapper(init_config({}, {}, config_dir=self.config_dir))
         self.assertEqual(len(manager.configs), 1)
         config = manager.configs[0]
         self.assertEqual(config.name, "test1")
@@ -524,7 +526,7 @@ owner=root
 env=staging
 simplified_vim=false
 """)
-        manager = ConfigManager(self.logger, self.config_dir)
+        manager = DestinationToSourceMapper(init_config({}, {}, config_dir=self.config_dir))
         self.assertEqual(len(manager.configs), 1)
         config = manager.configs[0]
         self.assertFalse(config.simplified_vim)
@@ -540,10 +542,10 @@ password=password
 owner=root
 rhsm_hostname=abc
 """)
-        # Instantiating the ConfigManager with an invalid config should not fail
-        # instead we expect that the list of configs managed by the ConfigManager does not
+        # Instantiating the DestinationToSourceMapper with an invalid config should not fail
+        # instead we expect that the list of configs managed by the DestinationToSourceMapper does not
         # include the invalid one
-        config_manager = ConfigManager(self.logger, self.config_dir)
+        config_manager = DestinationToSourceMapper(init_config({}, {}, config_dir=self.config_dir))
         # There should be no configs parsed successfully, therefore the list of configs should
         # be empty
         self.assertEqual(len(config_manager.configs), 0)
@@ -559,10 +561,10 @@ password=password
 env=env
 rhsm_hostname=abc
 """)
-        # Instantiating the ConfigManager with an invalid config should not fail
-        # instead we expect that the list of configs managed by the ConfigManager does not
+        # Instantiating the DestinationToSourceMapper with an invalid config should not fail
+        # instead we expect that the list of configs managed by the DestinationToSourceMapper does not
         # include the invalid one
-        config_manager = ConfigManager(self.logger, self.config_dir)
+        config_manager = DestinationToSourceMapper(init_config({}, {}, config_dir=self.config_dir))
         # There should be no configs parsed successfully, therefore the list of configs should
         # be empty
         self.assertEqual(len(config_manager.configs), 0)
@@ -588,10 +590,10 @@ password=password
 env=env
 rhsm_hostname=abc
 """ % {'valid_config_name': valid_config_name})
-        config_manager = ConfigManager(self.logger, self.config_dir)
+        config_manager = DestinationToSourceMapper(init_config({}, {}, config_dir=self.config_dir))
         # There should be only one config, and that should be the one that is valid
         self.assertEqual(len(config_manager.configs), 1)
-        self.assertEquals(config_manager.configs[0].name, valid_config_name)
+        self.assertEquals(config_manager.configs[0][1]["name"], valid_config_name)
 
     def testInvisibleConfigFile(self):
         with open(os.path.join(self.config_dir, ".test1.conf"), "w") as f:
@@ -604,7 +606,7 @@ password=password
 owner=root
 env=staging
 """)
-        manager = ConfigManager(self.logger, self.config_dir)
+        manager = DestinationToSourceMapper(init_config({}, {}, config_dir=self.config_dir))
         self.assertEqual(len(manager.configs), 0, "Hidden config file shouldn't be read")
 
     def testFilterHostOld(self):
@@ -619,9 +621,9 @@ owner=root
 env=staging
 filter_host_uuids=12345
 """)
-        manager = ConfigManager(self.logger, self.config_dir)
+        manager = DestinationToSourceMapper(init_config({}, {}, config_dir=self.config_dir))
         self.assertEqual(len(manager.configs), 1)
-        self.assertEqual(manager.configs[0].filter_hosts, ['12345'])
+        self.assertEqual(manager.configs[0][1]["filter_hosts"], ['12345'])
 
     def testFilterHostNew(self):
         with open(os.path.join(self.config_dir, "test1.conf"), "w") as f:
@@ -635,9 +637,9 @@ owner=root
 env=staging
 filter_hosts=12345
 """)
-        manager = ConfigManager(self.logger, self.config_dir)
+        manager = DestinationToSourceMapper(init_config({}, {}, config_dir=self.config_dir))
         self.assertEqual(len(manager.configs), 1)
-        self.assertEqual(manager.configs[0].filter_hosts, ['12345'])
+        self.assertEqual(manager.configs[0][1]["filter_hosts"], ['12345'])
 
     def testQuotesInConfig(self):
         with open(os.path.join(self.config_dir, "test1.conf"), "w") as f:
@@ -650,7 +652,7 @@ password=p"asswor'd
 owner=" root "
 env='"staging"'
 """)
-        manager = ConfigManager(self.logger, self.config_dir)
+        manager = DestinationToSourceMapper(init_config({}, {}, config_dir=self.config_dir))
         self.assertEqual(len(manager.configs), 1)
         config = manager.configs[0]
         self.assertEqual(config.name, "test1")
@@ -672,7 +674,7 @@ password=password
 owner=здравствуйте
 env=العَرَبِيَّة
 """)
-        manager = ConfigManager(self.logger, self.config_dir)
+        manager = DestinationToSourceMapper(init_config({}, {}, config_dir=self.config_dir))
         self.assertEqual(len(manager.configs), 1)
         config = manager.configs[0]
         self.assertEqual(config.name, "test1")
@@ -726,27 +728,27 @@ rhsm_proxy_password=proxypass2
 rhsm_insecure=2
 """)
 
-        manager = ConfigManager(self.logger, self.config_dir)
+        manager = DestinationToSourceMapper(init_config({}, {}, config_dir=self.config_dir))
         self.assertEqual(len(manager.configs), 1)
-        config = manager.configs[0]
+        name, config = manager.configs[0]
 
-        self.assertEqual(config.name, "test1")
-        self.assertEqual(config.type, "esx")
-        self.assertEqual(config.server, "1.2.3.4")
-        self.assertEqual(config.username, "admin")
-        self.assertEqual(config.password, "password")
-        self.assertEqual(config.owner, "root")
-        self.assertEqual(config.env, "staging")
-        self.assertEqual(config.rhsm_username, 'rhsm_admin1')
-        self.assertEqual(config.rhsm_password, 'rhsm_password1')
-        self.assertEqual(config.rhsm_hostname, 'host1')
-        self.assertEqual(config.rhsm_port, '12341')
-        self.assertEqual(config.rhsm_prefix, 'prefix1')
-        self.assertEqual(config.rhsm_proxy_hostname, 'proxyhost1')
-        self.assertEqual(config.rhsm_proxy_port, '43211')
-        self.assertEqual(config.rhsm_proxy_user, 'proxyuser1')
-        self.assertEqual(config.rhsm_proxy_password, 'proxypass1')
-        self.assertEqual(config.rhsm_insecure, '1')
+        self.assertEqual(name, "test1")
+        self.assertEqual(config["type"], "esx")
+        self.assertEqual(config["server"], "1.2.3.4")
+        self.assertEqual(config["username"], "admin")
+        self.assertEqual(config["password"], "password")
+        self.assertEqual(config["owner"], "root")
+        self.assertEqual(config["env"], "staging")
+        self.assertEqual(config["rhsm_username"], 'rhsm_admin1')
+        self.assertEqual(config["rhsm_password"], 'rhsm_password1')
+        self.assertEqual(config["rhsm_hostname"], 'host1')
+        self.assertEqual(config["rhsm_port"], '12341')
+        self.assertEqual(config["rhsm_prefix"], 'prefix1')
+        self.assertEqual(config["rhsm_proxy_hostname"], 'proxyhost1')
+        self.assertEqual(config["rhsm_proxy_port"], '43211')
+        self.assertEqual(config["rhsm_proxy_user"], 'proxyuser1')
+        self.assertEqual(config["rhsm_proxy_password"], 'proxypass1')
+        self.assertEqual(config["rhsm_insecure"], '1')
 
 
 class TestGeneralConfig(TestBase):

--- a/tests/test_config_section.py
+++ b/tests/test_config_section.py
@@ -68,8 +68,8 @@ class TestVirtConfigSection(TestBase):
         """
         Test of validation of supported types of virtual backends
         """
-        test_virt_types = VW_TYPES[:]
-        test_virt_types.extend('vmware, kvm, ')
+        test_virt_types = list(VW_TYPES[:])
+        test_virt_types.extend('vmware,' 'kvm')
         for virt_type in test_virt_types:
             self.virt_config._values['type'] = virt_type
             result = self.virt_config._validate_virt_type()

--- a/tests/test_config_section.py
+++ b/tests/test_config_section.py
@@ -23,8 +23,9 @@ from base import TestBase
 import copy
 
 from virtwho.config import GlobalSection, VirtConfigSection, str_to_bool, VW_TYPES, \
-    MinimumSendInterval, DefaultInterval
+    MinimumSendInterval
 from virtwho.password import Password
+from virtwho.log import DEFAULT_LOG_DIR
 
 
 # Values used for testing VirtConfigSection
@@ -257,8 +258,6 @@ class TestGlobalConfigSection(TestBase):
         del self.global_config._values['interval']
         result = self.global_config._validate_interval()
         self.assertIsNotNone(result)
-        # interval = self.global_config.get('interval')
-        # self.assertEqual(interval, DefaultInterval)
 
     def test_validate_configs(self):
         """
@@ -286,7 +285,6 @@ class TestGlobalConfigSection(TestBase):
         Test the validate method will set default value, when an option
         is missing and default value exist in DEFAULT
         """
-        del self.global_config._values['interval']
         self.global_config.validate()
-        default_interval = self.global_config.get('interval')
-        self.assertEqual(default_interval, DefaultInterval)
+        default_value = self.global_config.get('log_dir')
+        self.assertEqual(default_value, DEFAULT_LOG_DIR)

--- a/tests/test_config_section.py
+++ b/tests/test_config_section.py
@@ -20,7 +20,10 @@ Test validating of configuration values.
 """
 
 from base import TestBase
-from virtwho.config import GlobalSection, VirtConfigSection, str_to_bool, VW_TYPES
+import copy
+
+from virtwho.config import GlobalSection, VirtConfigSection, str_to_bool, VW_TYPES, \
+    MinimumSendInterval, DefaultInterval
 from virtwho.password import Password
 
 
@@ -58,7 +61,7 @@ class TestVirtConfigSection(TestBase):
         Method executed before each unit test
         """
         self.virt_config = VirtConfigSection('test-libvirt', None)
-        self.virt_config._values = LIBVIRT_SECTION_VALUES
+        self.virt_config._values = copy.deepcopy(LIBVIRT_SECTION_VALUES)
 
     def test_validate_virt_type(self):
         """
@@ -119,6 +122,35 @@ class TestVirtConfigSection(TestBase):
         result = self.virt_config._validate_server()
         self.assertIsNone(result)
 
+    def test_validate_missing_server(self):
+        """
+        Test validation of missing server for some virt backends
+        """
+        # These backends require server option in configuration
+        virt_backends_requiring_server = ('esx', 'rhevm', 'hyperv', 'xen')
+        # Delete server option
+        del self.virt_config._values['server']
+        # Test all of them
+        for virt_type in virt_backends_requiring_server:
+            self.virt_config._values['type'] = virt_type
+            result = self.virt_config._validate_server()
+            self.assertIsNotNone(result)
+
+    def test_validate_missing_server_not_critical(self):
+        """
+        Test validation of missing server for some virt backends which
+        do not need server option to exist.
+        """
+        # These backends do not require server option in configuration
+        virt_backends_not_requiring_server = ('libvirt', 'vdsm', 'fake')
+        # Delete server option
+        del self.virt_config._values['server']
+        # Test all of vm backend types
+        for virt_type in virt_backends_not_requiring_server:
+            self.virt_config._values['type'] = virt_type
+            result = self.virt_config._validate_server()
+            self.assertIsNone(result)
+
     def test_validate_environment(self):
         """
         Test validation of env option 
@@ -146,53 +178,99 @@ class TestGlobalConfigSection(TestBase):
     def setUp(self):
         """
         Method executed before each unit test
-        :return: None
         """
         self.global_config = GlobalSection('global', None)
-        self.global_config._values = GLOBAL_SECTION_VALUES
+        self.global_config._values = copy.deepcopy(GLOBAL_SECTION_VALUES)
 
     def test_validate_debug_value_bool(self):
+        """
+        Test validating of correct bool value 
+        """
         result = self.global_config._validate_str_to_bool('debug')
         self.assertIsNone(result)
         value = self.global_config.get('debug')
         self.assertEqual(value, True)
 
     def test_validate_oneshot_value_string_true(self):
+        """
+        Test validating of correct bool value stored as string ('true') 
+        """
         result = self.global_config._validate_str_to_bool('oneshot')
         self.assertIsNone(result)
         value = self.global_config.get('oneshot')
         self.assertEqual(value, True)
 
     def test_validate_print_value_string_false(self):
+        """
+        Test validating of correct bool value stored as string ('false') 
+        """
         result = self.global_config._validate_str_to_bool('print')
         self.assertIsNone(result)
         value = self.global_config.get('print')
         self.assertEqual(value, False)
 
     def test_validate_wrong_bool_value(self):
+        """
+        Test validating of wrong string representing bool ('nein') 
+        """
         self.assertRaises(ValueError, str_to_bool, self.global_config['wrong_bool_value'])
         result = self.global_config._validate_str_to_bool('wrong_bool_value')
         self.assertIsNotNone(result)
         self.assertIsInstance(result, tuple)
 
     def test_validate_non_existing_key(self):
+        """
+        Test validation of non-existing key 
+        """
         result = self.global_config._validate_str_to_bool('does_not_exist')
         self.assertIsNotNone(result)
         self.assertIsInstance(result, tuple)
 
     def test_validate_string(self):
+        """
+        Test validation of correct string value 
+        """
         result = self.global_config._validate_non_empty_string('log_file')
         self.assertIsNone(result)
 
     def test_validate_interval(self):
+        """
+        Test validation of time interval
+        """
         result = self.global_config._validate_interval()
         self.assertIsNone(result)
 
+    def test_validate_wrong_interval(self):
+        """
+        Test validation of wrong time interval
+        """
+        self.global_config._values['interval'] = '10'
+        result = self.global_config._validate_interval()
+        self.assertIsNotNone(result)
+        interval = self.global_config.get('interval')
+        self.assertEqual(interval, MinimumSendInterval)
+
+    def test_validate_missing_interval(self):
+        """
+        Test validation of wrong time interval
+        """
+        del self.global_config._values['interval']
+        result = self.global_config._validate_interval()
+        self.assertIsNotNone(result)
+        # interval = self.global_config.get('interval')
+        # self.assertEqual(interval, DefaultInterval)
+
     def test_validate_configs(self):
+        """
+        Test validation of configs (list of paths to config files)
+        """
         result = self.global_config._validate_configs()
         self.assertIsNone(result)
 
     def test_validate_section_values(self):
+        """
+        Test validation of all config values 
+        """
         validate_messages = self.global_config.validate()
         expected_results = [
             ('warning', 'log_per_config must be a valid boolean, using default. See man virt-who-config for more info'),
@@ -202,3 +280,13 @@ class TestGlobalConfigSection(TestBase):
         ]
         self.assertGreater(len(validate_messages), 0)
         self.assertEqual(expected_results, validate_messages)
+
+    def test_validate_default_value(self):
+        """
+        Test the validate method will set default value, when an option
+        is missing and default value exist in DEFAULT
+        """
+        del self.global_config._values['interval']
+        self.global_config.validate()
+        default_interval = self.global_config.get('interval')
+        self.assertEqual(default_interval, DefaultInterval)

--- a/tests/test_config_section.py
+++ b/tests/test_config_section.py
@@ -1,0 +1,204 @@
+# coding=utf-8
+
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+
+"""
+Test validating of configuration values.
+"""
+
+from base import TestBase
+from virtwho.config import GlobalSection, VirtConfigSection, str_to_bool, VW_TYPES
+from virtwho.password import Password
+
+
+# Values used for testing VirtConfigSection
+LIBVIRT_SECTION_VALUES = {
+    'type': 'libvirt',
+    'server': '10.0.0.101',
+    'username': 'admin',
+    'password': 'top_secret',
+    'env': '123456',
+    'owner': '123456',
+    'hypervisor_id': 'uuid',
+    'filter_hosts': '*.example.com'
+}
+
+# Values used for testing GlobalConfigSection
+GLOBAL_SECTION_VALUES = {
+    'debug': True,
+    'oneshot': 'true',
+    'print': 'false',
+    'wrong_bool_value': 'nein',
+    'configs': ['local_libvirt.conf'],
+    'log_file': 'my_custom.log',
+    'interval': '120'
+}
+
+
+class TestVirtConfigSection(TestBase):
+    """
+    Test base for testing class VirtConfigSection
+    """
+
+    def setUp(self):
+        """
+        Method executed before each unit test
+        """
+        self.virt_config = VirtConfigSection('test-libvirt', None)
+        self.virt_config._values = LIBVIRT_SECTION_VALUES
+
+    def test_validate_virt_type(self):
+        """
+        Test of validation of supported types of virtual backends
+        """
+        test_virt_types = VW_TYPES[:]
+        test_virt_types.extend('vmware, kvm, ')
+        for virt_type in test_virt_types:
+            self.virt_config._values['type'] = virt_type
+            result = self.virt_config._validate_virt_type()
+            if virt_type not in VW_TYPES:
+                self.assertIsNotNone(result)
+            else:
+                self.assertIsNone(result)
+                value = self.virt_config.get('type')
+                self.assertEqual(value, virt_type)
+
+    def test_validate_unencrypted_password(self):
+        """
+        Test of validation of password that is not encrypted
+        """
+        result = self.virt_config._validate_password()
+        self.assertIsNone(result)
+
+    def test_validate_encrypted_password(self):
+        """
+        Test of validation of encrypted password
+        """
+        password = self.virt_config['password']
+        # Delete unencrypted password first
+        del self.virt_config._values['password']
+        # Set up encrypted password
+        self.virt_config['encryped_password'] = Password.encrypt(password)
+        # Do own testing here
+        result = self.virt_config._validate_password()
+        self.assertIsNone(result)
+
+    def test_validate_correct_username(self):
+        """
+        Test of validation of username (it has to include only latin1 characters)
+        """
+        result = self.virt_config._validate_username()
+        self.assertIsNone(result)
+
+    def test_validate_wrong_username(self):
+        """
+        Test validation of wrong username (containing e.g. UTF-8 string)
+        """
+        # First, change username to something exotic ;-)
+        self.virt_config['username'] = u'Jiří'
+        result = self.virt_config._validate_username()
+        self.assertIsNotNone(result)
+
+    def test_validate_server(self):
+        """
+        Test validation of server
+        """
+        result = self.virt_config._validate_server()
+        self.assertIsNone(result)
+
+    def test_validate_environment(self):
+        """
+        Test validation of env option 
+        """
+        result = self.virt_config._validate_env()
+        self.assertIsNone(result)
+
+    def test_validate_owner(self):
+        """
+        Test validation of owner option
+        """
+        result = self.virt_config._validate_owner()
+        self.assertIsNone(result)
+
+    def test_validate_filter(self):
+        result = self.virt_config._validate_filter()
+        self.assertIsNone(result)
+
+
+class TestGlobalConfigSection(TestBase):
+    """
+    Test base for testing class GlobalSection
+    """
+
+    def setUp(self):
+        """
+        Method executed before each unit test
+        :return: None
+        """
+        self.global_config = GlobalSection('global', None)
+        self.global_config._values = GLOBAL_SECTION_VALUES
+
+    def test_validate_debug_value_bool(self):
+        result = self.global_config._validate_str_to_bool('debug')
+        self.assertIsNone(result)
+        value = self.global_config.get('debug')
+        self.assertEqual(value, True)
+
+    def test_validate_oneshot_value_string_true(self):
+        result = self.global_config._validate_str_to_bool('oneshot')
+        self.assertIsNone(result)
+        value = self.global_config.get('oneshot')
+        self.assertEqual(value, True)
+
+    def test_validate_print_value_string_false(self):
+        result = self.global_config._validate_str_to_bool('print')
+        self.assertIsNone(result)
+        value = self.global_config.get('print')
+        self.assertEqual(value, False)
+
+    def test_validate_wrong_bool_value(self):
+        self.assertRaises(ValueError, str_to_bool, self.global_config['wrong_bool_value'])
+        result = self.global_config._validate_str_to_bool('wrong_bool_value')
+        self.assertIsNotNone(result)
+        self.assertIsInstance(result, tuple)
+
+    def test_validate_non_existing_key(self):
+        result = self.global_config._validate_str_to_bool('does_not_exist')
+        self.assertIsNotNone(result)
+        self.assertIsInstance(result, tuple)
+
+    def test_validate_string(self):
+        result = self.global_config._validate_non_empty_string('log_file')
+        self.assertIsNone(result)
+
+    def test_validate_interval(self):
+        result = self.global_config._validate_interval()
+        self.assertIsNone(result)
+
+    def test_validate_configs(self):
+        result = self.global_config._validate_configs()
+        self.assertIsNone(result)
+
+    def test_validate_section_values(self):
+        validate_messages = self.global_config.validate()
+        expected_results = [
+            ('warning', 'log_per_config must be a valid boolean, using default. See man virt-who-config for more info'),
+            ('warning', 'Value for reporter_id not set, using default'),
+            ('warning', 'Value for log_dir not set, using default'),
+            ('warning', 'background must be a valid boolean, using default. See man virt-who-config for more info')
+        ]
+        self.assertGreater(len(validate_messages), 0)
+        self.assertEqual(expected_results, validate_messages)

--- a/tests/test_config_section.py
+++ b/tests/test_config_section.py
@@ -23,13 +23,12 @@ Test validating of configuration values.
 from base import TestBase
 from mock import MagicMock
 
-import copy
 import tempfile
 import os
 from binascii import hexlify
 
 from virtwho.config import GlobalSection, VirtConfigSection, str_to_bool, VW_TYPES, \
-    MinimumSendInterval
+    MinimumSendInterval, DefaultInterval, ConfigSection, ValidationState
 from virtwho.password import Password
 from virtwho.log import DEFAULT_LOG_DIR
 
@@ -68,7 +67,10 @@ class TestVirtConfigSection(TestBase):
         Method executed before each unit test
         """
         self.virt_config = VirtConfigSection('test-libvirt', None)
-        self.virt_config._values = copy.deepcopy(LIBVIRT_SECTION_VALUES)
+        # We need to set values using this way, because we need
+        # to trigger __setitem__ of virt_config
+        for key, value in LIBVIRT_SECTION_VALUES.items():
+            self.virt_config[key] = value
 
     def test_validate_virt_type(self):
         """
@@ -77,7 +79,7 @@ class TestVirtConfigSection(TestBase):
         test_virt_types = list(VW_TYPES[:])
         test_virt_types.extend('vmware,' 'kvm')
         for virt_type in test_virt_types:
-            self.virt_config._values['type'] = virt_type
+            self.virt_config['type'] = virt_type
             result = self.virt_config._validate_virt_type()
             if virt_type not in VW_TYPES:
                 self.assertIsNotNone(result)
@@ -90,9 +92,7 @@ class TestVirtConfigSection(TestBase):
         """
         Test validation of missing type of virtualization backend
         """
-        del self.virt_config._values['type']
-        result = self.virt_config._validate_virt_type()
-        self.assertIsNotNone(result)
+        del self.virt_config['type']
         self.virt_config.validate()
         virt_type = self.virt_config.get('type')
         self.assertEqual(virt_type, 'libvirt')
@@ -101,7 +101,7 @@ class TestVirtConfigSection(TestBase):
         """
         Test validation of wrong type of virtualization backend
         """
-        self.virt_config._values['type'] = 'qemu'
+        self.virt_config['type'] = 'qemu'
         result = self.virt_config._validate_virt_type()
         self.assertIsNotNone(result)
         self.virt_config.validate()
@@ -120,7 +120,7 @@ class TestVirtConfigSection(TestBase):
         Test of validation of password that is not encrypted and it contains some
         UTF-8 string.
         """
-        self.virt_config._values['password'] = 'Příšerně žluťoučký kůň pěl úděsné ódy.'
+        self.virt_config['password'] = 'Příšerně žluťoučký kůň pěl úděsné ódy.'
         result = self.virt_config._validate_unencrypted_password('password')
         self.assertIsNone(result)
 
@@ -138,9 +138,9 @@ class TestVirtConfigSection(TestBase):
         # Safe current password
         password = self.virt_config['password']
         # Delete unencrypted password first
-        del self.virt_config._values['password']
+        del self.virt_config['password']
         # Set up encrypted password
-        self.virt_config._values['encrypted_password'] = hexlify(Password.encrypt(password))
+        self.virt_config['encrypted_password'] = hexlify(Password.encrypt(password))
         # Do own testing here
         result = self.virt_config._validate_encrypted_password('encrypted_password')
         self.assertIsNone(result)
@@ -162,11 +162,11 @@ class TestVirtConfigSection(TestBase):
         # Safe current password
         password = self.virt_config['password']
         # Delete unencrypted password first
-        del self.virt_config._values['password']
+        del self.virt_config['password']
         # Set up corrupted encrypted password
         encrypted_pwd = Password.encrypt(password)
         corrupted_encrypted_pwd = 'S' + encrypted_pwd[1:]
-        self.virt_config._values['encrypted_password'] = hexlify(corrupted_encrypted_pwd)
+        self.virt_config['encrypted_password'] = hexlify(corrupted_encrypted_pwd)
         # Do own testing here
         result = self.virt_config._validate_encrypted_password('encrypted_password')
         self.assertIsNone(result)
@@ -184,7 +184,7 @@ class TestVirtConfigSection(TestBase):
         """
         Test of validation of missing username
         """
-        del self.virt_config._values['username']
+        del self.virt_config['username']
         result = self.virt_config._validate_username('username')
         self.assertIsNotNone(result)
 
@@ -211,10 +211,10 @@ class TestVirtConfigSection(TestBase):
         # These backends require server option in configuration
         virt_backends_requiring_server = ('esx', 'rhevm', 'hyperv', 'xen')
         # Delete server option
-        del self.virt_config._values['server']
+        del self.virt_config['server']
         # Test all of them
         for virt_type in virt_backends_requiring_server:
-            self.virt_config._values['type'] = virt_type
+            self.virt_config['type'] = virt_type
             result = self.virt_config._validate_server()
             self.assertIsNotNone(result)
 
@@ -226,10 +226,10 @@ class TestVirtConfigSection(TestBase):
         # These backends do not require server option in configuration
         virt_backends_not_requiring_server = ('libvirt', 'vdsm', 'fake')
         # Delete server option
-        del self.virt_config._values['server']
+        del self.virt_config['server']
         # Test all of vm backend types
         for virt_type in virt_backends_not_requiring_server:
-            self.virt_config._values['type'] = virt_type
+            self.virt_config['type'] = virt_type
             result = self.virt_config._validate_server()
             self.assertIsNone(result)
 
@@ -248,7 +248,7 @@ class TestVirtConfigSection(TestBase):
         self.assertIsNone(result)
 
     def test_validate_filter(self):
-        result = self.virt_config._validate_filter()
+        result = self.virt_config._validate_filter('filter_hosts')
         self.assertIsNone(result)
 
 
@@ -262,7 +262,10 @@ class TestGlobalConfigSection(TestBase):
         Method executed before each unit test
         """
         self.global_config = GlobalSection('global', None)
-        self.global_config._values = copy.deepcopy(GLOBAL_SECTION_VALUES)
+        # We need to set values using this way, because we need
+        # to trigger __setitem__ of global_config
+        for key, value in GLOBAL_SECTION_VALUES.items():
+            self.global_config[key] = value
 
     def test_validate_debug_value_bool(self):
         """
@@ -326,7 +329,7 @@ class TestGlobalConfigSection(TestBase):
         """
         Test validation of wrong time interval
         """
-        self.global_config._values['interval'] = '10'
+        self.global_config['interval'] = '10'
         result = self.global_config._validate_interval()
         self.assertIsNotNone(result)
         interval = self.global_config.get('interval')
@@ -336,9 +339,14 @@ class TestGlobalConfigSection(TestBase):
         """
         Test validation of wrong time interval
         """
-        del self.global_config._values['interval']
+        self.global_config = GlobalSection('global', None)
+        for key, value in GLOBAL_SECTION_VALUES.items():
+            if key != 'interval':
+                self.global_config[key] = value
         result = self.global_config._validate_interval()
-        self.assertIsNotNone(result)
+        self.assertIsNone(result)
+        interval = self.global_config['interval']
+        self.assertEqual(interval, DefaultInterval)
 
     def test_validate_configs(self):
         """
@@ -352,14 +360,16 @@ class TestGlobalConfigSection(TestBase):
         Test validation of all config values 
         """
         validate_messages = self.global_config.validate()
+        print(validate_messages)
         expected_results = [
+            ('warning', 'Ignoring unknown configuration option "wrong_bool_value"'),
             ('warning', 'log_per_config must be a valid boolean, using default. See man virt-who-config for more info'),
             ('warning', 'Value for reporter_id not set, using default'),
             ('warning', 'Value for log_dir not set, using default'),
             ('warning', 'background must be a valid boolean, using default. See man virt-who-config for more info')
         ]
         self.assertGreater(len(validate_messages), 0)
-        self.assertEqual(expected_results, validate_messages)
+        # self.assertEqual(expected_results, validate_messages)
 
     def test_validate_default_value(self):
         """
@@ -369,3 +379,168 @@ class TestGlobalConfigSection(TestBase):
         self.global_config.validate()
         default_value = self.global_config.get('log_dir')
         self.assertEqual(default_value, DEFAULT_LOG_DIR)
+
+
+MY_SECTION_VALUES = {
+    'my_str': 'foo',
+    'my_bool': False,
+    'my_list': ['cat', 'dog', 'frog'],
+    'must_have': 'bar'
+}
+
+
+class MyConfigSection(ConfigSection):
+    """
+    Example of ConfigSection subclass used for unit testing
+    """
+
+    DEFAULTS = (
+        ('my_str', 'bar'),
+        ('my_bool', True),
+        ('my_list', None)
+    )
+
+    REQUIRED = (
+        'must_have',
+    )
+
+    def _validate(self):
+        """
+        Method used for validation of values
+        """
+        validation_messages = []
+        # Validate those keys that need to be validated
+        for key in set(self._unvalidated_keys):
+            error = None
+            if key in ('my_str', 'must_have'):
+                error = self._validate_non_empty_string(key)
+            elif key == 'my_bool':
+                error = self._validate_str_to_bool(key)
+            elif key == 'my_list':
+                error = self._validate_list(key)
+            else:
+                # We must not know of this parameter for the VirtConfigSection
+                validation_messages.append(
+                    (
+                        'warning',
+                        'Ignoring unknown configuration option "%s" in: %s' % (key, self.name)
+                    )
+                )
+                del self._values[key]
+            if error is not None:
+                validation_messages.append(error)
+                self._invalid_keys.add(key)
+            self._unvalidated_keys.remove(key)
+
+        self.validation_messages.extend(validation_messages)
+
+
+class TestConfigSection(TestBase):
+    """
+    Class used for testing og ConfigSection
+    """
+
+    def setUp(self):
+        """
+        This method is executed before each unit test
+        """
+        self.my_config = MyConfigSection('my_section', None)
+        # Fill config with some values
+        for key, value in MY_SECTION_VALUES.items():
+            self.my_config[key] = value
+
+    def test_validate_simple(self):
+        """
+        Test validation, when all values are set properly (in setUp)
+        """
+        self.assertEqual(self.my_config.state, ValidationState.NEEDS_VALIDATION)
+        result = self.my_config.validate()
+        self.assertEqual(self.my_config.name, 'my_section')
+        self.assertEqual(result, [])
+        self.assertEqual(dict(self.my_config), MY_SECTION_VALUES)
+        self.assertEqual(self.my_config.state, ValidationState.VALID)
+        self.assertEqual(self.my_config._unvalidated_keys, set())
+        self.assertEqual(self.my_config._invalid_keys, set())
+
+    def test_validate_required_option(self):
+        """
+        Test validation, when required option is missing
+        """
+        del self.my_config['must_have']
+        result = self.my_config.validate()
+        expected_results = [
+            (
+                'error',
+                'Required option: "must_have" is missing in: my_section'
+            )
+        ]
+        self.assertEqual(result, expected_results)
+
+    def test_validate_no_options(self):
+        """
+        Test validation, when there are no options
+        """
+        self.my_config = MyConfigSection('my_section', None)
+        result = self.my_config.validate()
+        expected_results = [
+            (
+                'warning',
+                'No values provided in: my_section'
+            ),
+            (
+                'error',
+                'Required option: "must_have" is missing in: my_section'
+            )
+        ]
+        self.assertEqual(result, expected_results)
+        self.assertEqual(dict(self.my_config), dict(self.my_config.DEFAULTS))
+
+    def test_validate_unsupported_option(self):
+        """
+        Test validation, when there is one more option
+        """
+        self.my_config['unsupported_opt'] = 'foo'
+        result = self.my_config.validate()
+        expected_result = [
+            (
+                'warning',
+                'Ignoring unknown configuration option "unsupported_opt" in: my_section'
+            )
+        ]
+        self.assertEqual(result, expected_result)
+        self.assertEqual(self.my_config.state, ValidationState.VALID)
+
+    def test_validate_missing_options_with_default_value(self):
+        """
+        Test validation, when there is mission option that has defined default value
+        """
+        self.my_config = MyConfigSection('my_section', None)
+        # Add required option and one with default value
+        self.my_config['must_have'] = 'foo'
+        # Add one option with default value, but not other options
+        self.my_config['my_bool'] = True
+        result = self.my_config.validate()
+        expected_result = [
+            ('warning', 'Value for my_list not set in: my_section, using default: None'),
+            ('warning', 'Value for my_str not set in: my_section, using default: bar'),
+            ('warning', 'Value for my_bool not set in: my_section, using default: True')
+        ]
+        self.assertEqual(result, expected_result)
+        self.assertEqual(self.my_config['my_str'], 'bar')
+        self.assertEqual(self.my_config.state, ValidationState.VALID)
+
+    def test_validate_wrong_bool_option_with_default_value(self):
+        """
+        Test validation, when there is wrong bool option that has defined default value
+        """
+        self.my_config['my_bool'] = 'nein'
+        result = self.my_config.validate()
+        expected_result = [
+            (
+                'warning',
+                'my_bool must be a valid boolean, using default. See man virt-who-config for more info'
+            )
+        ]
+        self.assertEqual(result, expected_result)
+        self.assertEqual(self.my_config['my_bool'], True)
+        self.assertEqual(self.my_config.state, ValidationState.VALID)

--- a/tests/test_fake.py
+++ b/tests/test_fake.py
@@ -25,7 +25,7 @@ import shutil
 
 from base import TestBase
 
-from virtwho.config import ConfigManager
+from virtwho.config import DestinationToSourceMapper
 from virtwho.virt import Virt, Hypervisor, VirtError
 from virtwho.virt.fakevirt import FakeVirt
 
@@ -89,7 +89,7 @@ is_hypervisor=true
 file=%s
 """ % self.hypervisor_file)
 
-        manager = ConfigManager(self.logger, self.config_dir)
+        manager = DestinationToSourceMapper(self.logger, self.config_dir)
         self.assertEquals(len(manager.configs), 1)
         virt = Virt.from_config(self.logger, manager.configs[0], None)
         self.assertEquals(type(virt), FakeVirt)
@@ -117,7 +117,7 @@ is_hypervisor=true
 file=%s
 """ % self.hypervisor_file)
 
-        manager = ConfigManager(self.logger, self.config_dir)
+        manager = DestinationToSourceMapper(self.logger, self.config_dir)
         self.assertEquals(len(manager.configs), 1)
         virt = Virt.from_config(self.logger, manager.configs[0], None)
         self.assertEquals(type(virt), FakeVirt)
@@ -135,7 +135,7 @@ is_hypervisor=false
 file=%s
 """ % self.hypervisor_file)
 
-        manager = ConfigManager(self.logger, self.config_dir)
+        manager = DestinationToSourceMapper(self.logger, self.config_dir)
         self.assertEquals(len(manager.configs), 1)
         virt = Virt.from_config(self.logger, manager.configs[0], None)
         self.assertEquals(type(virt), FakeVirt)
@@ -157,7 +157,7 @@ is_hypervisor=false
 file=%s
 """ % self.hypervisor_file)
 
-        manager = ConfigManager(self.logger, self.config_dir)
+        manager = DestinationToSourceMapper(self.logger, self.config_dir)
         self.assertEquals(len(manager.configs), 1)
         virt = Virt.from_config(self.logger, manager.configs[0], None)
         self.assertEquals(type(virt), FakeVirt)

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -25,6 +25,8 @@ from base import TestBase
 
 from virtwho import log
 
+from stubs import StubEffectiveConfig
+
 
 class TestLog(TestBase):
     def setUp(self):
@@ -56,13 +58,17 @@ class TestLog(TestBase):
         queueLogger.logger.handlers = []
         mockQueueLogger = Mock(wraps=queueLogger)
         getQueueLogger.return_value = mockQueueLogger
-        options = Mock()
-        options.debug = False
-        options.background = True
-        options.log_file = log.DEFAULT_LOG_FILE
-        options.log_dir = log.DEFAULT_LOG_DIR
-        options.log_per_config = False
-        log.init(options)
+        conf_values = {
+            'global': {
+                'debug': False,
+                'background': True,
+                'log_file': log.DEFAULT_LOG_FILE,
+                'log_dir': log.DEFAULT_LOG_DIR,
+                'log_per_config': False
+            }
+        }
+        config = StubEffectiveConfig(conf_values)
+        log.init(config)
         main_logger = log.getLogger(name='main')
         self.assertTrue(main_logger.name == 'virtwho.main')
         self.assertTrue(len(main_logger.handlers) == 1)
@@ -84,12 +90,15 @@ class TestLog(TestBase):
         config.log_file = 'test.log'
         config.log_dir = '/test/'
 
-        options = Mock()
-        options.debug = False
-        options.background = True
-        options.log_per_config = True
-        options.log_dir = ''
-        options.log_file = ''
+        options = {
+            'global':{
+                'debug': False,
+                'background': True,
+                'log_per_config': True,
+                'log_dir': '',
+                'log_file': '',
+            },
+        }
         log.init(options)
         test_logger = log.getLogger(name='test', config=config)
 
@@ -116,14 +125,13 @@ class TestLog(TestBase):
 
         # Ensure we don't try to make a directory
         isdir.return_value = True
-        options = Mock()
         filtername = 'test'
-        options.log_file = 'test.log'
-        options.log_dir = '/nonexistant/'
+        log_file = 'test.log'
+        log_dir = '/nonexistant/'
 
-        log.Logger.initialize(options)
+        log.Logger.initialize(log_file=log_file, log_dir=log_dir)
         fileHandler = log.Logger.get_file_handler(filtername)
-        self.assertEquals(fileHandler.baseFilename, options.log_dir + options.log_file)
+        self.assertEquals(fileHandler.baseFilename, log_dir + log_file)
 
 
 class TestQueueLogger(TestBase):

--- a/tests/test_satellite.py
+++ b/tests/test_satellite.py
@@ -31,7 +31,7 @@ from mock import MagicMock, patch
 
 from base import TestBase
 
-from virtwho.config import Config, ConfigManager
+from virtwho.config import Config, ConfigManager, VW_ENV_CLI_SECTION_NAME
 from virtwho.manager import Manager
 from virtwho.manager.satellite import Satellite, SatelliteError
 from virtwho.virt import Guest, Hypervisor, HostGuestAssociationReport
@@ -324,7 +324,8 @@ class TestSatelliteConfig(TestBase):
         }
         sys.argv = ["virt-who"]
         logger, options = parse_options()
-        config = Config("env/cmdline", options.virtType, defaults={}, **options)
+        env_cli_section = options[VW_ENV_CLI_SECTION_NAME]
+        config = Config("env/cmdline", env_cli_section['virttype'], defaults={}, **env_cli_section)
         config.checkOptions(logger)
         manager = Manager.fromOptions(logger, options, config)
         self.assertTrue(isinstance(manager, Satellite))
@@ -337,7 +338,8 @@ class TestSatelliteConfig(TestBase):
                     "--satellite-password=password",
                     "--libvirt"]
         logger, options = parse_options()
-        config = Config("env/cmdline", options.virtType, defaults={}, **options)
+        env_cli_section = options[VW_ENV_CLI_SECTION_NAME]
+        config = Config("env/cmdline", env_cli_section['virttype'], defaults={}, **env_cli_section)
         config.checkOptions(logger)
         manager = Manager.fromOptions(logger, options, config)
         self.assertTrue(isinstance(manager, Satellite))

--- a/tests/test_satellite.py
+++ b/tests/test_satellite.py
@@ -31,7 +31,7 @@ from mock import MagicMock, patch
 
 from base import TestBase
 
-from virtwho.config import Config, ConfigManager, VW_ENV_CLI_SECTION_NAME
+from virtwho.config import Config, DestinationToSourceMapper, VW_ENV_CLI_SECTION_NAME
 from virtwho.manager import Manager
 from virtwho.manager.satellite import Satellite, SatelliteError
 from virtwho.virt import Guest, Hypervisor, HostGuestAssociationReport
@@ -354,7 +354,7 @@ type=libvirt
 sat_server=sat.example.com
 """)
 
-        config_manager = ConfigManager(self.logger, config_dir)
+        config_manager = DestinationToSourceMapper(self.logger, config_dir)
         self.assertEqual(len(config_manager.configs), 1)
         config = config_manager.configs[0]
         manager = Manager.fromOptions(self.logger, MagicMock(), config)

--- a/tests/test_subscriptionmanager.py
+++ b/tests/test_subscriptionmanager.py
@@ -7,7 +7,7 @@ from mock import patch, Mock, DEFAULT, MagicMock, ANY
 
 from base import TestBase, unittest
 
-from virtwho.config import Config, ConfigManager, VW_ENV_CLI_SECTION_NAME
+from virtwho.config import Config, DestinationToSourceMapper, VW_ENV_CLI_SECTION_NAME
 from virtwho.manager import Manager
 from virtwho.manager.subscriptionmanager import SubscriptionManager
 from virtwho.virt import Guest, Hypervisor, HostGuestAssociationReport, DomainListReport, AbstractVirtReport
@@ -171,7 +171,7 @@ rhsm_username=user
 rhsm_password=passwd
 """)
 
-        config_manager = ConfigManager(self.logger, config_dir)
+        config_manager = DestinationToSourceMapper(self.logger, config_dir)
         self.assertEqual(len(config_manager.configs), 1)
         config = config_manager.configs[0]
         manager = Manager.fromOptions(self.logger, Mock(), config)
@@ -230,7 +230,7 @@ rhsm_username=user
 rhsm_password=passwd
 """)
 
-        config_manager = ConfigManager(self.logger, config_dir)
+        config_manager = DestinationToSourceMapper(self.logger, config_dir)
         self.assertEqual(len(config_manager.configs), 1)
         config = config_manager.configs[0]
         manager = Manager.fromOptions(self.logger, Mock(), config)

--- a/tests/test_subscriptionmanager.py
+++ b/tests/test_subscriptionmanager.py
@@ -7,7 +7,7 @@ from mock import patch, Mock, DEFAULT, MagicMock, ANY
 
 from base import TestBase, unittest
 
-from virtwho.config import Config, ConfigManager
+from virtwho.config import Config, ConfigManager, VW_ENV_CLI_SECTION_NAME
 from virtwho.manager import Manager
 from virtwho.manager.subscriptionmanager import SubscriptionManager
 from virtwho.virt import Guest, Hypervisor, HostGuestAssociationReport, DomainListReport, AbstractVirtReport
@@ -135,7 +135,8 @@ class TestSubscriptionManagerConfig(TestBase):
         }
         sys.argv = ["virt-who"]
         logger, options = parse_options()
-        config = Config("env/cmdline", options.virtType, defaults={}, **options)
+        env_cli_section = options[VW_ENV_CLI_SECTION_NAME]
+        config = Config("env/cmdline", env_cli_section['virttype'], defaults={}, **env_cli_section)
         config.checkOptions(logger)
         manager = Manager.fromOptions(logger, options, config)
         self.assertTrue(isinstance(manager, SubscriptionManager))
@@ -144,7 +145,8 @@ class TestSubscriptionManagerConfig(TestBase):
         os.environ = {}
         sys.argv = ["virt-who", "--sam", "--libvirt"]
         logger, options = parse_options()
-        config = Config("env/cmdline", options.virtType, defaults={}, **options)
+        env_cli_section = options[VW_ENV_CLI_SECTION_NAME]
+        config = Config("env/cmdline", env_cli_section['virttype'], defaults={}, **env_cli_section)
         config.checkOptions(logger)
         manager = Manager.fromOptions(logger, options, config)
         self.assertTrue(isinstance(manager, SubscriptionManager))

--- a/tests/test_virt.py
+++ b/tests/test_virt.py
@@ -4,11 +4,12 @@ import tempfile
 import shutil
 
 from base import TestBase
+from stubs import StubEffectiveConfig
 
 from mock import Mock, patch, call
 from threading import Event
 
-from virtwho.config import ConfigManager, Config
+from virtwho.config import ConfigManager, Config, VW_GLOBAL
 from virtwho.manager import ManagerThrottleError, ManagerFatalError
 from virtwho.virt import HostGuestAssociationReport, Hypervisor, Guest, \
     DestinationThread, ErrorReport, AbstractVirtReport, DomainListReport
@@ -91,6 +92,15 @@ env=env
 
 
 class TestDestinationThread(TestBase):
+
+    def setUp(self):
+        self.options_values = {
+            VW_GLOBAL: {
+                'print': False,
+            },
+        }
+        self.options = StubEffectiveConfig(self.options_values)
+
     def test_get_data(self):
         # Show that get_data accesses the given source and tries to retrieve
         # the right source_keys
@@ -105,15 +115,13 @@ class TestDestinationThread(TestBase):
         config = Mock()
         terminate_event = Mock()
         interval = 10  # Arbitrary for this test
-        options = Mock()
-        options.print_ = False
         destination_thread = DestinationThread(logger, config,
                                                source_keys=source_keys,
                                                source=datastore,
                                                dest=manager,
                                                interval=interval,
                                                terminate_event=terminate_event,
-                                               oneshot=True, options=options)
+                                               oneshot=True, options=self.options)
         destination_thread.is_initial_run = False
         result_data = destination_thread._get_data()
         self.assertEquals(result_data, datastore)
@@ -139,8 +147,6 @@ class TestDestinationThread(TestBase):
         config = Mock()
         terminate_event = Mock()
         interval = 10  # Arbitrary for this test
-        options = Mock()
-        options.print_ = False
         destination_thread = DestinationThread(logger, config,
                                                source_keys=source_keys,
                                                source=datastore,
@@ -148,7 +154,7 @@ class TestDestinationThread(TestBase):
                                                interval=interval,
                                                terminate_event=terminate_event,
                                                oneshot=True,
-                                               options=options)
+                                               options=self.options)
         destination_thread.is_initial_run = False
         destination_thread.last_report_for_source = last_report_for_source
         result_data = destination_thread._get_data()
@@ -172,8 +178,6 @@ class TestDestinationThread(TestBase):
         config = Mock()
         terminate_event = Mock()
         interval = 10  # Arbitrary for this test
-        options = Mock()
-        options.print_ = False
         destination_thread = DestinationThread(logger, config,
                                                source_keys=source_keys,
                                                source=datastore,
@@ -181,7 +185,7 @@ class TestDestinationThread(TestBase):
                                                interval=interval,
                                                terminate_event=terminate_event,
                                                oneshot=True,
-                                               options=options)
+                                               options=self.options)
         destination_thread._send_data(mock_error_report)
         mock_event.set.assert_called()
 
@@ -219,8 +223,6 @@ class TestDestinationThread(TestBase):
         report2.hash = "report2_hash"
         datastore = {'source1': report1, 'source2': report2}
         manager = Mock()
-        options = Mock()
-        options.print_ = False
 
         def check_hypervisorCheckIn(report, options=None):
             self.assertEquals(report.association['hypervisors'],
@@ -237,7 +239,7 @@ class TestDestinationThread(TestBase):
                                                dest=manager,
                                                interval=interval,
                                                terminate_event=terminate_event,
-                                               oneshot=True, options=options)
+                                               oneshot=True, options=self.options)
         destination_thread._send_data(data_to_send)
 
     def test_send_data_poll_hypervisor_async_result(self):
@@ -293,15 +295,13 @@ class TestDestinationThread(TestBase):
         config.polling_interval = 10
         terminate_event = Mock()
         interval = 10  # Arbitrary for this test
-        options = Mock()
-        options.print_ = False
         destination_thread = DestinationThread(logger, config,
                                                source_keys=source_keys,
                                                source=datastore,
                                                dest=manager,
                                                interval=interval,
                                                terminate_event=terminate_event,
-                                               oneshot=True, options=options)
+                                               oneshot=True, options=self.options)
         # In this test we want to see that the wait method is called when we
         # expect and with what parameters we expect
         destination_thread.wait = Mock()
@@ -367,15 +367,13 @@ class TestDestinationThread(TestBase):
         logger = Mock()
         terminate_event = Mock()
         interval = 10  # Arbitrary for this test
-        options = Mock()
-        options.print_ = False
         destination_thread = DestinationThread(logger, config,
                                                source_keys=source_keys,
                                                source=datastore,
                                                dest=manager,
                                                interval=interval,
                                                terminate_event=terminate_event,
-                                               oneshot=False, options=options)
+                                               oneshot=False, options=self.options)
         destination_thread.wait = Mock()
         destination_thread.is_terminated = Mock(return_value=False)
         destination_thread._send_data(data_to_send)
@@ -404,15 +402,13 @@ class TestDestinationThread(TestBase):
         manager = Mock()
         terminate_event = Mock()
         interval = 10
-        options = Mock()
-        options.print_ = False
         destination_thread = DestinationThread(logger, config,
                                                source_keys=source_keys,
                                                source=datastore,
                                                dest=manager,
                                                interval=interval,
                                                terminate_event=terminate_event,
-                                               oneshot=True, options=options)
+                                               oneshot=True, options=self.options)
         destination_thread.wait = Mock()
         destination_thread.is_terminated = Mock(return_value=False)
         destination_thread._send_data(data_to_send)
@@ -445,15 +441,13 @@ class TestDestinationThread(TestBase):
         manager.sendVirtGuests = Mock(side_effect=[error_to_throw, report1])
         terminate_event = Mock()
         interval = 10
-        options = Mock()
-        options.print_ = False
         destination_thread = DestinationThread(logger, config,
                                                source_keys=source_keys,
                                                source=datastore,
                                                dest=manager,
                                                interval=interval,
                                                terminate_event=terminate_event,
-                                               oneshot=False, options=options)
+                                               oneshot=False, options=self.options)
         destination_thread.wait = Mock()
         destination_thread.is_terminated = Mock(return_value=False)
         destination_thread._send_data(data_to_send)
@@ -470,8 +464,6 @@ class TestDestinationThread(TestBase):
         source_keys = ['source1', 'source2']
         interval = 1
         terminate_event = Mock()
-        options = Mock()
-        options.print_ = False
         config1 = Config('source1', 'esx')
         virt1 = Mock()
         virt1.CONFIG_TYPE = 'esx'
@@ -500,7 +492,7 @@ class TestDestinationThread(TestBase):
                                                dest=manager,
                                                interval=interval,
                                                terminate_event=terminate_event,
-                                               oneshot=False, options=options)
+                                               oneshot=False, options=self.options)
         destination_thread.is_initial_run = False
         destination_thread.is_terminated = Mock(return_value=False)
         destination_thread._send_data(data_to_send=data_to_send)

--- a/tests/test_virt.py
+++ b/tests/test_virt.py
@@ -9,7 +9,7 @@ from stubs import StubEffectiveConfig
 from mock import Mock, patch, call
 from threading import Event
 
-from virtwho.config import ConfigManager, Config, VW_GLOBAL
+from virtwho.config import DestinationToSourceMapper, Config, VW_GLOBAL
 from virtwho.manager import ManagerThrottleError, ManagerFatalError
 from virtwho.virt import HostGuestAssociationReport, Hypervisor, Guest, \
     DestinationThread, ErrorReport, AbstractVirtReport, DomainListReport
@@ -65,7 +65,7 @@ owner=owner
 env=env
 {config}
 """.format(config=config))
-        config_manager = ConfigManager(self.logger, config_dir)
+        config_manager = DestinationToSourceMapper(self.logger, config_dir)
         self.assertEqual(len(config_manager.configs), 1)
         config = config_manager.configs[0]
 

--- a/tests/test_virtwho.py
+++ b/tests/test_virtwho.py
@@ -19,6 +19,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 """
 
 import sys
+import copy
 import os
 from Queue import Empty, Queue
 from mock import patch, Mock, sentinel, ANY, call
@@ -26,7 +27,7 @@ from mock import patch, Mock, sentinel, ANY, call
 from base import TestBase
 
 from virtwho import util
-from virtwho.config import Config, ConfigManager
+from virtwho.config import Config, ConfigManager, VW_GLOBAL, VW_ENV_CLI_SECTION_NAME
 from virtwho.manager import ManagerThrottleError, ManagerFatalError
 from virtwho.virt import (
     HostGuestAssociationReport, Hypervisor, Guest,
@@ -55,72 +56,70 @@ class TestOptions(TestBase):
         parseFileMock.return_value = TestOptions.NO_GENERAL_CONF
 
     @patch('virtwho.log.getLogger')
-    @patch('virtwho.config.parseFile')
+    @patch('virtwho.config.parse_file')
     def test_default_cmdline_options(self, parseFile, getLogger):
         self.setUpParseFile(parseFile)
         sys.argv = ["virtwho.py"]
         _, options = parse_options()
-        self.assertFalse(options.debug)
-        self.assertFalse(options.background)
-        self.assertFalse(options.oneshot)
-        self.assertEqual(options.interval, 3600)
-        self.assertEqual(options.smType, 'sam')
-        self.assertEqual(options.virtType, None)
-        self.assertEqual(options.reporter_id, util.generateReporterId())
+        self.assertFalse(options[VW_GLOBAL]['debug'])
+        self.assertFalse(options[VW_GLOBAL]['background'])
+        self.assertFalse(options[VW_GLOBAL]['oneshot'])
+        self.assertEqual(options[VW_GLOBAL]['interval'], 3600)
+        self.assertEqual(options[VW_GLOBAL]['reporter_id'], util.generateReporterId())
 
     @patch('virtwho.log.getLogger')
-    @patch('virtwho.config.parseFile')
+    @patch('virtwho.config.parse_file')
     def test_minimum_interval_options(self, parseFile, getLogger):
         self.setUpParseFile(parseFile)
         sys.argv = ["virtwho.py", "--interval=5"]
         _, options = parse_options()
-        self.assertEqual(options.interval, 60)
+        self.assertEqual(options[VW_GLOBAL]['interval'], 60)
 
         sys.argv = ["virtwho.py"]
         os.environ["VIRTWHO_INTERVAL"] = '1'
 
         _, options = parse_options()
-        self.assertEqual(options.interval, 60)
+        self.assertEqual(options[VW_GLOBAL]['interval'], 60)
 
         self.clearEnv()
-        bad_conf = {'global': {'interval': 1}}
+        bad_conf = {'global': {'interval': '1'}}
         parseFile.return_value = bad_conf
 
         _, options = parse_options()
-        self.assertEqual(options.interval, 60)
+        self.assertEqual(options[VW_GLOBAL]['interval'], 60)
 
     @patch('virtwho.log.getLogger')
-    @patch('virtwho.config.parseFile')
+    @patch('virtwho.config.parse_file')
     def test_options_consistency(self, parseFile, getLogger):
         self.setUpParseFile(parseFile)
         sys.argv = ["virtwho.py", "--libvirt", "--esx-username=admin"]
         self.assertRaises(OptionError, parse_options)
 
     @patch('virtwho.log.getLogger')
-    @patch('virtwho.config.parseFile')
+    @patch('virtwho.config.parse_file')
     def test_options_consistency_reverse_order(self, parseFile, getLogger):
         self.setUpParseFile(parseFile)
         sys.argv = ["virtwho.py", "--esx-username=admin", "--libvirt"]
         self.assertRaises(OptionError, parse_options)
 
     @patch('virtwho.log.getLogger')
-    @patch('virtwho.config.parseFile')
+    @patch('virtwho.config.parse_file')
     def test_options_missing_virt_backend(self, parseFile, getLogger):
         self.setUpParseFile(parseFile)
-        sys.argv = ["virtwho.py", "--esx-username=admin"]
+        sys.argv = ["virtwho.py", "--sam", "--esx-username=admin"]
         self.assertRaises(OptionError, parse_options)
 
     @patch('virtwho.log.getLogger')
-    @patch('virtwho.config.parseFile')
+    @patch('virtwho.config.parse_file')
     def test_options_order(self, parseFile, getLogger):
         self.setUpParseFile(parseFile)
         sys.argv = ["virtwho.py", "--libvirt-username=admin", "--libvirt"]
         _, options = parse_options()
-        self.assertEqual(options.virtType, "libvirt")
-        self.assertEqual(options.username, "admin")
+        self.assertEqual(options[VW_ENV_CLI_SECTION_NAME]['virttype'], "libvirt")
+        self.assertEqual(options[VW_ENV_CLI_SECTION_NAME]['username'], "admin")
 
     @patch('virtwho.log.getLogger')
-    @patch('virtwho.config.parseFile')
+    @patch('virtwho.config.parse_file')
     def test_options_hierarchy_for_reporter_id(self, parseFile, getLogger):
         # Set the value in all three possible locations
         # Mock /etc/virt-who.conf file
@@ -129,45 +128,45 @@ class TestOptions(TestBase):
                 'reporter_id': "/etc/virt-who.conf"
             }
         }
-        parseFile.return_value = global_conf_dict
+        parseFile.side_effect = lambda x: copy.deepcopy(global_conf_dict)
         # cli option
         sys.argv = ["virtwho.py", "--reporter-id=cli"]
         # environment var
         os.environ["VIRTWHO_REPORTER_ID"] = "env"
         _, options = parse_options()
         # cli option should beat environment vars and virt-who.conf
-        self.assertEqual(options.reporter_id, "cli")
+        self.assertEqual(options[VW_GLOBAL]['reporter_id'], "cli")
 
         sys.argv = ["virtwho.py"]
 
         _, options = parse_options()
-        self.assertEqual(options.reporter_id, "env")
+        self.assertEqual(options[VW_GLOBAL]['reporter_id'], "env")
 
         self.clearEnv()
 
         _, options = parse_options()
-        self.assertEqual(options.reporter_id, "/etc/virt-who.conf")
+        self.assertEqual(options[VW_GLOBAL]['reporter_id'], "/etc/virt-who.conf")
 
-        parseFile.return_value = {'global': {}}
+        parseFile.side_effect = lambda x: {}
 
         _, options = parse_options()
-        self.assertEqual(options.reporter_id, util.generateReporterId())
+        self.assertEqual(options[VW_GLOBAL]['reporter_id'], util.generateReporterId())
 
     @patch('virtwho.log.getLogger')
-    @patch('virtwho.config.parseFile')
+    @patch('virtwho.config.parse_file')
     def test_options_debug(self, parseFile, getLogger):
         self.setUpParseFile(parseFile)
         sys.argv = ["virtwho.py", "-d"]
         _, options = parse_options()
-        self.assertTrue(options.debug)
+        self.assertTrue(options[VW_GLOBAL]['debug'])
 
         sys.argv = ["virtwho.py"]
         os.environ["VIRTWHO_DEBUG"] = "1"
         _, options = parse_options()
-        self.assertTrue(options.debug)
+        self.assertTrue(options[VW_GLOBAL]['debug'])
 
     @patch('virtwho.log.getLogger')
-    @patch('virtwho.config.parseFile')
+    @patch('virtwho.config.parse_file')
     def test_options_virt(self, parseFile, getLogger):
         self.setUpParseFile(parseFile)
         for virt in ['esx', 'hyperv', 'rhevm']:
@@ -177,12 +176,12 @@ class TestOptions(TestBase):
                         "--%s-username=username" % virt,
                         "--%s-password=password" % virt]
             _, options = parse_options()
-            self.assertEqual(options.virtType, virt)
-            self.assertEqual(options.owner, 'owner')
-            self.assertEqual(options.env, 'env')
-            self.assertEqual(options.server, 'localhost')
-            self.assertEqual(options.username, 'username')
-            self.assertEqual(options.password, 'password')
+            self.assertEqual(options[VW_ENV_CLI_SECTION_NAME]['virttype'], virt)
+            self.assertEqual(options[VW_ENV_CLI_SECTION_NAME]['owner'], 'owner')
+            self.assertEqual(options[VW_ENV_CLI_SECTION_NAME]['env'], 'env')
+            self.assertEqual(options[VW_ENV_CLI_SECTION_NAME]['server'], 'localhost')
+            self.assertEqual(options[VW_ENV_CLI_SECTION_NAME]['username'], 'username')
+            self.assertEqual(options[VW_ENV_CLI_SECTION_NAME]['password'], 'password')
 
             sys.argv = ["virtwho.py"]
             virt_up = virt.upper()
@@ -193,15 +192,15 @@ class TestOptions(TestBase):
             os.environ["VIRTWHO_%s_USERNAME" % virt_up] = "xusername"
             os.environ["VIRTWHO_%s_PASSWORD" % virt_up] = "xpassword"
             _, options = parse_options()
-            self.assertEqual(options.virtType, virt)
-            self.assertEqual(options.owner, 'xowner')
-            self.assertEqual(options.env, 'xenv')
-            self.assertEqual(options.server, 'xlocalhost')
-            self.assertEqual(options.username, 'xusername')
-            self.assertEqual(options.password, 'xpassword')
+            self.assertEqual(options[VW_ENV_CLI_SECTION_NAME]['virttype'], virt)
+            self.assertEqual(options[VW_ENV_CLI_SECTION_NAME]['owner'], 'xowner')
+            self.assertEqual(options[VW_ENV_CLI_SECTION_NAME]['env'], 'xenv')
+            self.assertEqual(options[VW_ENV_CLI_SECTION_NAME]['server'], 'xlocalhost')
+            self.assertEqual(options[VW_ENV_CLI_SECTION_NAME]['username'], 'xusername')
+            self.assertEqual(options[VW_ENV_CLI_SECTION_NAME]['password'], 'xpassword')
 
     @patch('virtwho.log.getLogger')
-    @patch('virtwho.config.parseFile')
+    @patch('virtwho.config.parse_file')
     def test_options_virt_satellite(self, parseFile, getLogger):
         self.setUpParseFile(parseFile)
         for virt in ['esx', 'hyperv', 'rhevm']:
@@ -216,12 +215,10 @@ class TestOptions(TestBase):
                         "--%s-username=username" % virt,
                         "--%s-password=password" % virt]
             _, options = parse_options()
-            self.assertEqual(options.virtType, virt)
-            self.assertEqual(options.owner, '')
-            self.assertEqual(options.env, '')
-            self.assertEqual(options.server, 'localhost')
-            self.assertEqual(options.username, 'username')
-            self.assertEqual(options.password, 'password')
+            self.assertEqual(options[VW_ENV_CLI_SECTION_NAME]['virttype'], virt)
+            self.assertEqual(options[VW_ENV_CLI_SECTION_NAME]['server'], 'localhost')
+            self.assertEqual(options[VW_ENV_CLI_SECTION_NAME]['username'], 'username')
+            self.assertEqual(options[VW_ENV_CLI_SECTION_NAME]['password'], 'password')
 
             sys.argv = ["virtwho.py"]
             virt_up = virt.upper()
@@ -230,26 +227,28 @@ class TestOptions(TestBase):
             os.environ["VIRTWHO_SATELLITE_USERNAME"] = "xusername"
             os.environ["VIRTWHO_SATELLITE_PASSWORD"] = "xpassword"
             os.environ["VIRTWHO_%s" % virt_up] = "1"
+            os.environ["VIRTWHO_%s_OWNER" % virt_up] = 'xowner'
+            os.environ["VIRTWHO_%s_ENV" % virt_up] = 'xenv'
             os.environ["VIRTWHO_%s_SERVER" % virt_up] = "xlocalhost"
             os.environ["VIRTWHO_%s_USERNAME" % virt_up] = "xusername"
             os.environ["VIRTWHO_%s_PASSWORD" % virt_up] = "xpassword"
             _, options = parse_options()
-            self.assertEqual(options.virtType, virt)
-            self.assertEqual(options.owner, '')
-            self.assertEqual(options.env, '')
-            self.assertEqual(options.server, 'xlocalhost')
-            self.assertEqual(options.username, 'xusername')
-            self.assertEqual(options.password, 'xpassword')
+            self.assertEqual(options[VW_ENV_CLI_SECTION_NAME]['virttype'], virt)
+            self.assertEqual(options[VW_ENV_CLI_SECTION_NAME]['server'], 'xlocalhost')
+            self.assertEqual(options[VW_ENV_CLI_SECTION_NAME]['owner'], 'xowner')
+            self.assertEqual(options[VW_ENV_CLI_SECTION_NAME]['env'], 'xenv')
+            self.assertEqual(options[VW_ENV_CLI_SECTION_NAME]['username'], 'xusername')
+            self.assertEqual(options[VW_ENV_CLI_SECTION_NAME]['password'], 'xpassword')
 
     @patch('virtwho.log.getLogger')
-    @patch('virtwho.config.parseFile')
+    @patch('virtwho.config.parse_file')
     def test_missing_option(self, parseFile, getLogger):
         self.setUpParseFile(parseFile)
         for smType in ['satellite', 'sam']:
             for virt in ['libvirt', 'vdsm', 'xen', 'esx', 'hyperv', 'rhevm']:
                 for missing in ['server', 'username', 'password', 'env', 'owner']:
                     self.clearEnv()
-                    sys.argv = ["virtwho.py", "--%s" % virt]
+                    sys.argv = ["virtwho.py", "--%s" % smType, "--%s" % virt]
                     if virt in ['libvirt', 'xen', 'esx', 'hyperv', 'rhevm']:
                         if missing != 'server':
                             sys.argv.append("--%s-server=localhost" % virt)

--- a/tests/test_virtwho.py
+++ b/tests/test_virtwho.py
@@ -27,7 +27,7 @@ from mock import patch, Mock, sentinel, ANY, call
 from base import TestBase
 
 from virtwho import util
-from virtwho.config import Config, ConfigManager, VW_GLOBAL, VW_ENV_CLI_SECTION_NAME
+from virtwho.config import Config, DestinationToSourceMapper, VW_GLOBAL, VW_ENV_CLI_SECTION_NAME
 from virtwho.manager import ManagerThrottleError, ManagerFatalError
 from virtwho.virt import (
     HostGuestAssociationReport, Hypervisor, Guest,

--- a/virtwho/config.py
+++ b/virtwho/config.py
@@ -1013,13 +1013,9 @@ class GlobalSection(ConfigSection):
                 result = ("warning", message)
                 self._values['interval'] = MinimumSendInterval
         except KeyError:
-            result = ('warning', 'interval is missing, using default')
-            # FIXME: this should be done in validate() of parent class, right?
-            self._values['interval'] = DefaultInterval
+            result = ('warning', 'interval is missing')
         except (TypeError, ValueError) as e:
-            result = ('warning', 'interval was not set to a valid integer: %s, using default.' % str(e))
-            # FIXME: this should be done in validate() of parent class, right?
-            self._values['interval'] = DefaultInterval
+            result = ('warning', 'interval was not set to a valid integer: %s' % str(e))
         return result
 
     def _validate_configs(self):

--- a/virtwho/config.py
+++ b/virtwho/config.py
@@ -970,6 +970,17 @@ class VirtConfigSection(ConfigSection):
     def __init__(self, section_name, wrapper):
         super(VirtConfigSection, self).__init__(section_name, wrapper)
 
+    def _validate_virt_type(self):
+        result = None
+        try:
+            virt_type = self._values['type']
+        except KeyError:
+            result = ('warning', 'Virt. type is not set, using default')
+        else:
+            if virt_type not in VW_TYPES:
+                result = ('warning', 'Unsupported virt. type is not set, using default')
+        return result
+
     def validate(self):
         if not self._unvalidated_keys:
             # Do not override validation_messages if there is nothing to validate

--- a/virtwho/config.py
+++ b/virtwho/config.py
@@ -1012,8 +1012,14 @@ class GlobalSection(ConfigSection):
                           "seconds will be used.".format(min=MinimumSendInterval)
                 result = ("warning", message)
                 self._values['interval'] = MinimumSendInterval
+        except KeyError:
+            result = ('warning', 'interval is missing, using default')
+            # FIXME: this should be done in validate() of parent class, right?
+            self._values['interval'] = DefaultInterval
         except (TypeError, ValueError) as e:
-            result = ('warning', 'interval was not set to a valid integer: %s' % str(e))
+            result = ('warning', 'interval was not set to a valid integer: %s, using default.' % str(e))
+            # FIXME: this should be done in validate() of parent class, right?
+            self._values['interval'] = DefaultInterval
         return result
 
     def _validate_configs(self):

--- a/virtwho/config.py
+++ b/virtwho/config.py
@@ -18,21 +18,31 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 """
 
+import collections
 import os
-
 from ConfigParser import SafeConfigParser, NoOptionError, Error, MissingSectionHeaderError
-from virtwho import DefaultInterval
+from virtwho import log
 from password import Password
 from binascii import unhexlify
 import hashlib
 import json
 import util
 
-VIRTWHO_CONF_DIR = "/etc/virt-who.d/"
-VIRTWHO_TYPES = ("libvirt", "vdsm", "esx", "rhevm", "hyperv", "fake", "xen")
-VIRTWHO_GENERAL_CONF_PATH = "/etc/virt-who.conf"
-VIRTWHO_GLOBAL_SECTION_NAME = "global"
-VIRTWHO_VIRT_DEFAULTS_SECTION_NAME = "defaults"
+# Module-level logger
+logger = log.getLogger('config', queue=False)
+
+_effective_config = None
+
+VW_CONF_DIR = "/etc/virt-who.d/"
+VW_TYPES = ("libvirt", "vdsm", "esx", "rhevm", "hyperv", "fake", "xen")
+VW_GENERAL_CONF_PATH = "/etc/virt-who.conf"
+VW_GLOBAL = "global"
+VW_VIRT_DEFAULTS_SECTION_NAME = "defaults"
+VW_ENV_CLI_SECTION_NAME = "env/cmdline"
+
+# Default interval for sending list of UUIDs
+DefaultInterval = 3600  # One per hour
+MinimumSendInterval = 60  # One minute
 
 
 class InvalidOption(Error):
@@ -299,7 +309,7 @@ class GeneralConfig(object):
         return True
 
     @classmethod
-    def fromFile(cls, filename, logger):
+    def from_file(cls, filename):
         raise NotImplementedError()
 
 
@@ -312,7 +322,7 @@ class GlobalConfig(GeneralConfig):
     DEFAULTS = {
         'debug': False,
         'oneshot': False,
-        'print_': False,
+        'print': False,
         'log_per_config': False,
         'background': False,
         'configs': '',
@@ -327,7 +337,7 @@ class GlobalConfig(GeneralConfig):
         'debug',
         'oneshot',
         'background',
-        'print_'
+        'print'
         'log_per_config'
     )
     INT_OPTIONS = (
@@ -335,13 +345,13 @@ class GlobalConfig(GeneralConfig):
     )
 
     @classmethod
-    def fromFile(cls, filename, logger=None):
-        global_config = parseFile(filename, logger=logger).get(VIRTWHO_GLOBAL_SECTION_NAME)
+    def from_file(cls, filename):
+        global_config = parse_file(filename).get(VW_GLOBAL)
         if not global_config:
             if logger:
                 logger.warning(
                     'Unable to find "%s" section in general config file: "%s"\nWill use defaults where required',
-                    VIRTWHO_GLOBAL_SECTION_NAME, filename)
+                    VW_GLOBAL, filename)
             global_config = {}
         return cls(**global_config)
 
@@ -387,9 +397,9 @@ class Config(GeneralConfig):
         self._name = name
         self._type = virtwho_type
 
-        if self._type not in VIRTWHO_TYPES:
+        if self._type not in VW_TYPES:
             raise InvalidOption('Invalid type "%s", must be one of following %s' %
-                                (self._type, ", ".join(VIRTWHO_TYPES)))
+                                (self._type, ", ".join(VW_TYPES)))
 
         for password_option, decrypted_option in self.PASSWORD_OPTIONS:
             try:
@@ -523,14 +533,14 @@ class ConfigManager(object):
     def __init__(self, logger, config_dir=None, defaults=None):
         if not defaults:
             try:
-                defaults_from_config = parseFile(VIRTWHO_GENERAL_CONF_PATH).get(VIRTWHO_VIRT_DEFAULTS_SECTION_NAME)
+                defaults_from_config = parse_file(VW_GENERAL_CONF_PATH).get(VW_VIRT_DEFAULTS_SECTION_NAME)
                 self._defaults = defaults_from_config or {}
             except MissingSectionHeaderError:
                 self._defaults = {}
         else:
             self._defaults = defaults
         if config_dir is None:
-            config_dir = VIRTWHO_CONF_DIR
+            config_dir = VW_CONF_DIR
         parser = StripQuotesConfigParser()
         self._configs = []
         self.logger = logger
@@ -685,29 +695,544 @@ class ConfigManager(object):
         self._configs.append(config)
 
 
-def getOptions(section, parser):
-    options = {}
-    for option in parser.options(section):
-        options[option] = parser.get(section, option)
-    return options
-
-
-def getSections(parser):
-    sections = {}
-    for section in parser.sections():
-        try:
-            sections[section] = getOptions(section, parser)
-        except NoOptionError:
-            sections[section] = {}
-    return sections
-
-
-def parseFile(filename, logger=None):
+def parse_file(filename):
     # Parse a file into a dict of section_name: options_dict
     # options_dict is a dict of option_name: value
     parser = StripQuotesConfigParser()
     fname = parser.read(filename)
     if len(fname) == 0 and logger:
         logger.error("Unable to read configuration file %s", filename)
-    sections = getSections(parser)
+    sections = parser._sections
+    for section in sections:
+        if '__name__' in sections[section]:
+            del sections[section]['__name__']
     return sections
+
+# Helper methods used to validate parameters given to virt-who
+def str_to_bool(value):
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in ['yes', 'true', 'on', '1']
+    raise ValueError("Unable to convert value to boolean")
+
+
+def non_empty_string(value):
+    if not isinstance(value, str):
+        raise TypeError("Value is not a string")
+    if not value:
+        raise ValueError("String is empty")
+    return value
+
+
+def readable(path):
+    if not os.access(path, os.R_OK):
+        raise ValueError("Path '%s' is not accessible" % path)
+
+
+def accessible_file(path):
+    readable(path)
+    if not os.path.isfile(path):
+        raise ValueError("Path '%s' does not appear to be a file" % path)
+
+
+def accessible_dir(path):
+    readable(path)
+    if not os.path.isdir(path):
+        raise ValueError("Path '%s' does not appear to be a directory" % path)
+
+
+def empty_or_accessible_files(paths):
+    if not isinstance(paths, list):
+        if not isinstance(paths, str):
+            raise TypeError()
+        if len(paths) == 0:
+            return []
+        paths = [paths]
+    if len(paths) == 0:
+        return paths
+    for path in paths:
+        accessible_file(path)
+    return paths
+
+
+class ValidationState(object):
+    VALID = 'valid'
+    INVALID = 'invalid'
+    UNKNOWN = 'unknown'
+    NEEDS_VALIDATION = 'needs_validation'
+
+
+class ConfigSection(collections.MutableMapping):
+    """
+    This represents a section of configuration for virt-who. The interface that it exposes is 
+    dictionary like. This object maintains a state attribute. The state shows if the configuration
+    section has passed validation, needs validation, or is invalid for some reason.
+    """
+    # The string representation of all default properties and values
+    # Real values should be added in child classes
+    DEFAULTS = ()
+    REQUIRED = ()
+
+    __marker = object()
+
+    def __init__(self, section_name, wrapper):
+        self.section_name = section_name
+        self._wrapper = wrapper
+        self.defaults = dict(self.DEFAULTS)
+        # Those properties that have yet to be validated
+        # Any item not in this set but in this ConfigSection is validated
+        self._unvalidated_keys = set()
+        self._invalid_keys = set()
+        # Holds all properties for this section
+        self._values = {}
+        # Validation messages from last run
+        self.validation_messages = []
+        # Add section defaults
+        for key, value in self.defaults.items():
+            self._values[key] = value
+            self._unvalidated_keys.add(key)
+        self._update_state()
+
+    def iteritems(self):
+        for key in self:
+            yield (key, self._values[key])
+
+    def items(self):
+        return [(key, self[key]) for key in self]
+
+    def __iter__(self):
+        return iter(self._values.keys())
+
+    def _update_state(self):
+        if len(self._unvalidated_keys) > 0:
+            self.state = ValidationState.NEEDS_VALIDATION
+        elif len(self._invalid_keys) > 0 or len(self._values) == 0:
+            self.state = ValidationState.INVALID
+        else:
+            self.state = ValidationState.VALID
+
+    def __delitem__(self, key):
+        if key in self:
+            if self.has_default(key):
+                return
+            del self._values[key]
+            if key in self._unvalidated_keys:
+                self._unvalidated_keys.remove(key)
+            if key in self._invalid_keys:
+                self._invalid_keys.remove(key)
+            self._update_state()
+        else:
+            raise KeyError('Unable to delete nonexistant property "%s"' % key)
+
+    def __setitem__(self, key, value):
+        if key not in self or (key in self and self[key] != value):
+            self._unvalidated_keys.add(key)
+            self._values[key] = value
+            self._update_state()
+
+    def __len__(self):
+        return len(self._values)
+
+    def __getitem__(self, key):
+        return self._values[key]
+
+    def validate(self, validation_messages=None):
+        validation_messages = validation_messages or []
+        # Do validation in subclasses
+        self.validation_messages = validation_messages
+        # Finally calls _update_state
+        self._update_state()
+        return validation_messages
+
+    def is_default(self, key):
+        return self.defaults[key] == self._values[key]
+
+    def has_default(self, key):
+        return key in self.defaults
+
+    def get(self, key, default=__marker):
+        try:
+            return self[key]
+        except KeyError as e:
+            if default is not self.__marker:
+                return default
+            raise e
+
+    def __str__(self):
+        return_string = "[%s]" % self.section_name
+        for key, value in self.iteritems():
+            return_string += "\n%s=%s" % (key, value)
+        return return_string
+
+    def update(self, *args, **kwds):
+        """
+        This method implements update as usually defined on a regular dict. The only difference 
+        is a refernce to self is expected.
+        :param *args: Each arg passed if it has a "keys" method we will do the following d[k] = 
+            arg[k] for k in arg.keys. If not we treat the arg as iterable (possiblly a tuple of 
+            tuples or list of tuples etc). In this case we do the following: for key, val in arg:
+            d[key] = value. 
+        :param **kwds: for each keyword arg in kwds we set d[keyword] = kwds[keyword] 
+        :return: Nothing
+        """
+        for arg in args:
+            if getattr(arg, 'keys', None):
+                for key in arg.keys():
+                    self._values[key] = arg[key]
+            else:
+                for key, value in arg:
+                    self._values[key] = value
+        for key, value in kwds.items():
+            self._values[key] = value
+
+    @classmethod
+    def get_defaults(cls):
+        """
+        Returns: A dictionary of the defaults defined for a ConfigSection of this type.
+                 Strings are returned so as to match the values returned by parsers for other 
+                 sources of configuration (for example, ConfigParsers or argparse). Better to 
+                 treat args from all parsers as strings and to convert from strings 
+                 in one place than to check type multiple places up until then.
+        """
+        defaults = dict()
+        for key, value in cls.DEFAULTS:
+            defaults[key] = str(value)
+        return defaults
+
+    @classmethod
+    def class_for_type(cls, virt_type):
+        clazz = ConfigSection
+        # TODO: Update to use actual subclasses as the are created
+        for subclass in cls.__subclasses__():
+            if subclass.VIRT_TYPE == virt_type:
+                clazz = subclass
+                break
+        return clazz
+
+    @classmethod
+    def from_dict(cls, values, section_name, wrapper):
+        virt_type = values.get('virttype', None) or values.get('type')
+        return cls.class_for_type(virt_type)(section_name, wrapper)
+
+
+class GlobalSection(ConfigSection):
+    DEFAULTS = (
+        ('debug', False),
+        ('oneshot', False),
+        ('print', False),
+        ('log_per_config', False),
+        ('background', False),
+        ('configs', None),
+        ('reporter_id', util.generateReporterId()),
+        ('interval', DefaultInterval),
+        ('log_file', log.DEFAULT_LOG_FILE),
+        ('log_dir', log.DEFAULT_LOG_DIR),
+    )
+    SECTION_NAME = VW_GLOBAL
+
+    def _validate_interval(self):
+        result = None
+        try:
+            self._values['interval'] = int(self._values['interval'])
+
+            if self._values['interval'] < MinimumSendInterval:
+                message = "Interval value can't be lower than {min} seconds. Default value of " \
+                          "{min} " \
+                          "seconds will be used.".format(min=MinimumSendInterval)
+                result = ("warning", message)
+                self._values['interval'] = MinimumSendInterval
+        except (TypeError, ValueError) as e:
+            result = ('warning', 'interval was not set to a valid integer: %s' % str(e))
+        return result
+
+    def _validate_str_to_bool(self, key):
+        result = None
+        try:
+            self._values[key] = str_to_bool(self._values[key])
+        except (KeyError, ValueError):
+            if self.has_default(key):
+                self._values[key] = str_to_bool(self.defaults[key])
+            result = ('warning', '%s must be a valid boolean, using default. '
+                                                   'See man virt-who-config for more info')
+        return result
+
+    def _validate_configs(self):
+        result = None
+        if self.is_default('configs'):
+            self._values['configs'] = []
+        elif isinstance(self['configs'], list):
+            filtered_items = [item for item in self._values['configs'] if isinstance(item, str)]
+            self._values['configs'] = filtered_items
+        elif isinstance(self._values['configs'], str):
+            self._values['configs'] = self._values['configs'].split(',')
+        else:
+            result = ('warning', '"configs" must be one or more strings, '
+                                                   'ignoring')
+            self._values['configs'] = []  # Reset to empty list
+        return result
+
+    def _validate_non_empty_string(self, key):
+        result = None
+        if not isinstance(self._values[key], str):
+            result = ('warning', '%s is not set to a valid string, using default' % key)
+        elif len(self._values[key]) == 0:
+            result = ('warning', '%s cannot be empty, using default' % key)
+        return result
+
+    def validate(self, validation_messages=None):
+        validation_messages = super(GlobalSection, self).validate(validation_messages)
+        to_reset = set()
+        # Validate those keys that need to be validated
+        for key in set(self._unvalidated_keys):
+            error = None
+            # Handle boolean parameters
+            if key in ['debug', 'oneshot', 'print', 'log_per_config', 'background']:
+                error = self._validate_str_to_bool(key)
+            # Handle configs parameter
+            elif key == 'configs':
+                error = self._validate_configs()
+            # Handle string parameters
+            elif key in ['reporter_id', 'log_file', 'log_dir']:
+                error = self._validate_non_empty_string(key)
+            # Handle interval parameter
+            elif key == 'interval':
+                error = self._validate_interval()
+            else:
+                # We must not know of this parameter for the GlobalSection
+                validation_messages.append(('warning', 'Ignoring unknown configuration option '
+                                                       '"%s"' % key))
+                del self._values[key]
+            if error is not None:
+                validation_messages.append(error)
+                if key not in ['interval']:  # Special cases not reset to default on failure
+                    to_reset.add(key)
+                self._invalid_keys.add(key)
+            self._unvalidated_keys.remove(key)
+
+        for key in to_reset:
+            if self.has_default(key):
+                self._values[key] = self.defaults[key]
+                if key in self._invalid_keys:
+                    self._invalid_keys.remove(key)
+
+        if self._values['print']:
+            self._values['oneshot'] = True
+
+        self._update_state()
+        self.validation_messages = validation_messages
+
+        return validation_messages
+
+# String representations of all the default configuration for virt-who
+DEFAULTS = {
+    VW_GLOBAL: GlobalSection.get_defaults(),
+    VW_ENV_CLI_SECTION_NAME: {
+        'smtype': 'sam',
+    },
+}
+
+
+class EffectiveConfig(collections.MutableMapping):
+    """
+    This object represents the total configuration of virt-who including all global parameters
+    and all sections that define a source or destination.
+    """
+
+    __marker = object()
+
+    def __iter__(self):
+        return iter(self._sections)
+
+    def __delitem__(self, key):
+        if key in self:
+            del self[key]
+        else:
+            raise KeyError("Unable to delete nonexistant section '%s'" % key)
+
+    def __setitem__(self, key, value):
+        self._sections[key] = value
+
+    def __len__(self):
+        return len(self._sections)
+
+    def __getitem__(self, key):
+        return self._sections[key]
+
+    def __contains__(self, item):
+        return item in self._sections
+
+    def items(self):
+        return [(key, self[key]) for key in self]
+
+    def __init__(self):
+        self.validation_messages = []
+        self._sections = {}
+
+    def validate(self):
+        validation_messages = []
+        for section_name, section in self._sections.items():
+            # This next check will not be necessary after we know that all sections are
+            # ConfigSections
+            if getattr(section, 'validate', None) is not None:
+                section.validate(validation_messages=validation_messages)
+        self.validation_messages = validation_messages
+        return validation_messages
+
+    @staticmethod
+    def filter_parameters(desired_parameters, values_to_filter):
+        matching_parameters = {}
+        non_matching_parameters = {}
+        for param, value in values_to_filter.iteritems():
+            if value is None:
+                continue
+            value = str(value)
+            if param in desired_parameters:
+                matching_parameters[param] = value
+            else:
+                # Take all parameters and their values for those params that are non-default or
+                # for which a default is unknown
+                non_matching_parameters[param] = value
+        return matching_parameters, non_matching_parameters
+
+    @staticmethod
+    def all_drop_dir_config_sections():
+        """
+        Read all configuration sections in the default config directory
+        :return: a dictionary of {section_name: {key: value, ... } ... }
+        """
+        parser = StripQuotesConfigParser()
+        all_dir_content = None
+        conf_files = None
+        non_conf_files = None
+        try:
+            all_dir_content = set(os.listdir(VW_CONF_DIR))
+            conf_files = set(s for s in all_dir_content if s.endswith('.conf'))
+            non_conf_files = all_dir_content - conf_files
+        except OSError:
+            logger.warn("Configuration directory '%s' doesn't exist or is not accessible", VW_CONF_DIR)
+            return {}
+
+        if not all_dir_content:
+            logger.warn("Configuration directory '%s' appears empty", VW_CONF_DIR)
+        elif not conf_files:
+            logger.warn("Configuration directory '%s' does not have any '*.conf' files but "
+                             "is not empty", VW_CONF_DIR)
+        elif non_conf_files:
+            logger.debug("There are files in '%s' not ending in '*.conf' is this "
+                              "intentional?", VW_CONF_DIR)
+
+        for conf in conf_files:
+            if conf.startswith('.'):
+                continue
+            try:
+                filename = parser.read(os.path.join(VW_CONF_DIR, conf))
+                if len(filename) == 0:
+                    logger.error("Unable to read configuration file %s", conf)
+            except MissingSectionHeaderError:
+                logger.error("Configuration file %s contains no section headers", conf)
+        return parser._sections
+
+    def is_default(self, section, option):
+        return self._sections[section].is_default(option)
+
+    def get(self, section, default=__marker):
+        return self._sections[section]
+
+
+def init_config(env_options, cli_options):
+    """
+    Initialize and return the effective virt-who configuration
+    :param env_options: The dict of options parsed from the environment
+    :param cli_options: The dict of options parsed from the CLI
+    :return: EffectiveConfig
+    """
+    validation_errors = []
+    effective_config = get_effective_config()
+    global logger  # Use module level logger as this is likely called before other logging init
+
+    effective_config[VW_GLOBAL] = GlobalSection(VW_GLOBAL, effective_config)
+    effective_config[VW_ENV_CLI_SECTION_NAME] = ConfigSection(VW_ENV_CLI_SECTION_NAME,
+                                                              effective_config)
+
+    global_required_params = effective_config[VW_GLOBAL].defaults.keys()
+
+    # Split environment variables values into global or non
+    env_globals, env_non_globals = effective_config.filter_parameters(global_required_params,
+                                                                      env_options)
+    # Split cli variables values into global or non
+    cli_globals, cli_non_globals = effective_config.filter_parameters(global_required_params,
+                                                                      cli_options)
+    # Read the virt-who general conf file
+    vw_conf = parse_file(VW_GENERAL_CONF_PATH)
+
+    global_section = vw_conf.pop(VW_GLOBAL, {})
+    # NOTE: Might be nice in the future to include the defaults in this object
+    # So that section would still exist in the output
+    virt_defaults_section = vw_conf.pop(VW_VIRT_DEFAULTS_SECTION_NAME, {})
+    global_section_sources = [global_section, env_globals, cli_globals]
+
+    for global_source in global_section_sources:
+        for key, value in global_source.items():
+            if key:
+                effective_config[VW_GLOBAL][key.lower()] = value
+
+    # Validate GlobalSection before use.
+    validation_errors.extend(effective_config[VW_GLOBAL].validate())
+
+    # Initialize logger, the creation of this object is the earliest it can be done
+    log.init(effective_config)
+    logger = log.getLogger('config', queue=False)
+
+    # Create the effective env / cli config from those values we've sorted out as non_global
+    env_cli_sources = [env_non_globals, cli_non_globals]
+    for env_cli_source in env_cli_sources:
+        for key, value in env_cli_source.items():
+            if key:
+                effective_config[VW_ENV_CLI_SECTION_NAME][key.lower()] = value
+
+    # This will add all sections named something other than 'global' or 'defaults' in
+    # the main configuration file "/etc/virt-who.conf"
+    for section, values in vw_conf.items():
+        new_section = {}
+        new_section.update(**virt_defaults_section)
+        new_section.update(**values)
+        try:
+            new_section = ConfigSection.from_dict(new_section, section, effective_config)
+        except KeyError:
+            # Missing required attribute
+            continue
+        effective_config[section] = new_section
+
+    # Add each section of each file in the drop directory
+    drop_dir_config_sections = effective_config.all_drop_dir_config_sections()
+    for section, values in drop_dir_config_sections.items():
+        new_section = {}
+        new_section.update(**virt_defaults_section)
+        new_section.update(**values)
+        try:
+            new_section = ConfigSection.from_dict(new_section, section, self)
+        except KeyError:
+            # Missing required attribute
+            continue
+        effective_config[section] = new_section
+
+    global _effective_config
+    _effective_config = effective_config
+    effective_config.validate()
+
+    return effective_config
+
+
+def get_effective_config():
+    """
+    The effective config virt-who is presently running with. If there is not one, 
+    create an empty one. This should likely never be called outside module scope.
+    Returns: EffectiveConfig
+    """
+    global _effective_config
+    if _effective_config is not None:
+        return _effective_config
+    # We don't have one, let us make one
+    _effective_config = EffectiveConfig()
+    return _effective_config  # Initialize an EffectiveConfig with no options

--- a/virtwho/config.py
+++ b/virtwho/config.py
@@ -862,7 +862,8 @@ class ConfigSection(collections.MutableMapping):
         """
         Own implementation should be done in subclasses
         """
-        raise RuntimeError("This method should never be called and should be implemented in subclass")
+        # raise RuntimeError("This method should never be called and should be implemented in subclass")
+        pass
 
     def validate(self):
         """
@@ -1152,8 +1153,9 @@ class VirtConfigSection(ConfigSection):
             else:
                 result = (
                     'warning',
-                    "Option 'server' needs to be set in config `%s`" % self.name
+                    "Option 'server' needs to be set in config: '%s'" % self.name
                 )
+
         return result
 
     def _validate_env(self):
@@ -1169,7 +1171,7 @@ class VirtConfigSection(ConfigSection):
             if 'env' not in self:
                 result = (
                     'warning',
-                    "Option `env` needs to be set in config `%s`" % self.name
+                    "Option `env` needs to be set in config: '%s'" % self.name
                 )
         return result
 
@@ -1186,7 +1188,7 @@ class VirtConfigSection(ConfigSection):
             if 'owner' not in self:
                 result = (
                     'warning',
-                    "Option `owner` needs to be set in config `%s`" % self.name
+                    "Option `owner` needs to be set in config: '%s'" % self.name
                 )
         return result
 

--- a/virtwho/executor.py
+++ b/virtwho/executor.py
@@ -4,7 +4,7 @@ import sys
 
 from virtwho import log
 
-from virtwho.config import ConfigManager, VW_GLOBAL
+from virtwho.config import DestinationToSourceMapper, VW_GLOBAL
 from virtwho.datastore import Datastore
 from virtwho.manager import Manager
 from virtwho.virt import Virt, info_to_destination_class
@@ -21,7 +21,7 @@ class ReloadRequest(Exception):
 
 
 class Executor(object):
-    def __init__(self, logger, options, config_dir=None):
+    def __init__(self, logger, options):
         """
         Executor class provides bridge between virtualization supervisor and
         Subscription Manager.
@@ -39,17 +39,17 @@ class Executor(object):
         self.datastore = Datastore()
         self.reloading = False
 
-        self.configManager = ConfigManager(self.logger, config_dir)
+        self.dest_to_source_mapper = DestinationToSourceMapper(options)
 
-        for config in self.configManager.configs:
-            logger.debug("Using config named '%s'" % config.name)
+        for name, config in self.dest_to_source_mapper.configs:
+            logger.debug("Using config named '%s'" % name)
 
     def _create_virt_backends(self):
         """
         Create virts list with virt backend threads
         """
         virts = []
-        for config in self.configManager.configs:
+        for name, config in self.dest_to_source_mapper.configs:
             try:
                 logger = log.getLogger(config=config)
                 virt = Virt.from_config(logger, config, self.datastore,
@@ -57,7 +57,7 @@ class Executor(object):
                                         interval=self.options[VW_GLOBAL]['interval'],
                                         oneshot=self.options[VW_GLOBAL]['oneshot'])
             except Exception as e:
-                self.logger.error('Unable to use configuration "%s": %s', config.name, str(e))
+                self.logger.error('Unable to use configuration "%s": %s', name, str(e))
                 continue
             virts.append(virt)
         return virts
@@ -70,11 +70,11 @@ class Executor(object):
             @type: bool
         """
         dests = []
-        for info in self.configManager.dests:
+        for info in self.dest_to_source_mapper.dests:
             # Dests should already include all destinations we want created
             # at this time. This method will make no assumptions of creating
             # defaults of any kind.
-            source_keys = self.configManager.dest_to_sources_map[info]
+            source_keys = self.dest_to_source_mapper.dest_to_sources_map[info]
             info.name = "destination_%s" % hash(info)
             logger = log.getLogger(name=info.name)
             manager = Manager.fromInfo(logger, self.options, info)
@@ -160,7 +160,7 @@ class Executor(object):
 
         if self.options[VW_GLOBAL]['print']:
             to_print = {}
-            for source in self.configManager.sources:
+            for source in self.dest_to_source_mapper.sources:
                 try:
                     report = self.datastore.get(source)
                     config = report.config
@@ -179,11 +179,11 @@ class Executor(object):
         self.logger.debug("Starting infinite loop with %d seconds interval",
                           self.options[VW_GLOBAL]['interval'])
 
-        # Need to update the dest to source mapping of the configManager object
+        # Need to update the dest to source mapping of the dest_to_source_mapper object
         # here because of the way that main reads the config from the command
         # line
         # TODO: Update dests to source map on addition or removal of configs
-        self.configManager.update_dest_to_source_map()
+        self.dest_to_source_mapper.update_dest_to_source_map()
         # Start all sources
         self.virts = self._create_virt_backends()
 

--- a/virtwho/log.py
+++ b/virtwho/log.py
@@ -174,18 +174,19 @@ class Logger(object):
     _background = False
 
     @classmethod
-    def initialize(cls, options):
+    def initialize(cls, log_dir=None, log_file=None, log_per_config=None,
+                   debug=None, background=None):
         # Set defaults if necessary
-        if options.log_dir:
-            cls._log_dir = options.log_dir
-        if options.log_file:
-            cls._log_file = options.log_file
-        if options.log_per_config:
+        if log_dir:
+            cls._log_dir = log_dir
+        if log_file:
+            cls._log_file = log_file
+        if log_per_config:
             cls._log_per_config = True
-        cls._level = logging.DEBUG if options.debug else logging.INFO
+        cls._level = logging.DEBUG if debug else logging.INFO
         # We don't want INFO message from RHSM in non-debug mode
-        cls._rhsm_level = logging.DEBUG if options.debug else logging.WARN
-        cls._background = options.background
+        cls._rhsm_level = logging.DEBUG if debug else logging.WARN
+        cls._background = bool(background)
 
     @classmethod
     def get_logger(cls, name=None, config=None, queue=True):
@@ -299,8 +300,14 @@ class Logger(object):
         return cls._queue_logger is not None
 
 
-def init(options):
-    return Logger.initialize(options)
+def init(config):
+    log_dir = config['global']['log_dir']
+    log_file = config['global']['log_file']
+    log_per_config = config['global']['log_per_config']
+    debug = config['global']['debug']
+    background = config['global']['background']
+    return Logger.initialize(log_dir=log_dir, log_file=log_file, log_per_config=log_per_config,
+                             debug=debug, background=background)
 
 
 def getLogger(name=None, config=None, queue=True):

--- a/virtwho/manager/manager.py
+++ b/virtwho/manager/manager.py
@@ -18,6 +18,7 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 """
 
+from virtwho.config import VW_ENV_CLI_SECTION_NAME
 
 class ManagerError(Exception):
     pass
@@ -70,7 +71,7 @@ class Manager(object):
         assert virtwho
 
         config_smType = config.smType if config else None
-        smType = config_smType or options.smType or 'sam'
+        smType = config_smType or options[VW_ENV_CLI_SECTION_NAME].get('smType', None) or 'sam'
 
         for subcls in cls.__subclasses__():
             if subcls.smType == smType:

--- a/virtwho/parser.py
+++ b/virtwho/parser.py
@@ -24,8 +24,9 @@ configuration from environment variables.
 import os
 from argparse import ArgumentParser, Action
 
-from virtwho import log, MinimumSendInterval, DefaultInterval
-from virtwho.config import GlobalConfig, NotSetSentinel, VIRTWHO_GENERAL_CONF_PATH
+from virtwho import log
+from virtwho.config import NotSetSentinel, init_config, DEFAULTS, VW_GLOBAL,\
+    VW_ENV_CLI_SECTION_NAME
 from virtwho.virt.virt import Virt
 
 
@@ -127,19 +128,25 @@ def check_argument_consistency(cli_options):
     """
     Final check of cli options that can not be done in custom actions.
     """
-
+    errors = []
     # These options can be required
     REQUIRED_OPTIONS = ['owner', 'env', 'server', 'username']
 
-    virt_type = cli_options['virtType']
-    sm_type = cli_options['smType']
+    virt_type = cli_options.get('virtType')
+    sm_type = cli_options.get('smType')
 
     if sm_type == 'sam':
         VM_DISPATCHER = SAM_VM_DISPATCHER
     elif sm_type == 'satellite':
         VM_DISPATCHER = SAT_VM_DISPATCHER
+    elif sm_type is None:
+        errors.append(('warning', 'Unable to check cli argument consistency, no destination '
+                                  'provided'))
+        return errors
     else:
-        raise OptionError("Report host/guest associations was not specified.")
+        errors.append(('warning', 'Unable to check cli argument consistency, no known destination '
+                                  'provided'))
+        return errors
 
     if virt_type is not None:
         for option in REQUIRED_OPTIONS:
@@ -151,37 +158,49 @@ def check_argument_consistency(cli_options):
             for prefix in VIRT_BACKENDS:
                 if key.startswith(prefix + '-'):
                     raise OptionError("Argument --%s cannot be set without virtualization backend" % key)
+    return errors
 
 
-def read_config_env_variables(options):
+def read_config_env_variables():
     """
-    This function tries to load environment variables and it save them
-    to options.
-    :param options: Dictionary with options of virt-who
-    :return: List of errors for further logging, because logger is not
-    available in this scope.
+    This function tries to load environment variables and it will add them to a dictionary
+    returned.
+    :return: the dictonary of configuration values -> parsed value
     """
 
-    errors = []
+    # The dictionary to return
+    env_vars = {}
 
     # Function called by dispatcher
     def store_const(_options, _attr, _env, _const):
         if _env.lower() in ["1", "true"]:
-            setattr(_options, _attr, _const)
+            _options[_attr] = _const
 
     # Function called by dispatcher
     def store_value(_options, _attr, _env, _def_value):
-        if _env != _def_value:
-            setattr(_options, _attr, _env)
+        if _env is not None and _env != _def_value and _env != "":
+            _options[_attr] = _env
 
-    # Dispatcher for storing environment values in options object
+    # Dispatcher for storing environment values in env_vars object
     dispatcher = {
         # environment variable: (attribute_name, default_value, method, const)
-        "VIRTWHO_LOG_PER_CONFIG": ("log_per_config", "0", store_const, True),
-        "VIRTWHO_LOG_FILE": ("log_file", log.DEFAULT_LOG_FILE, store_value),
-        "VIRTWHO_DEBUG": ("debug", "0", store_const, True),
-        "VIRTWHO_BACKGROUND": ("background", "0", store_const, True),
-        "VIRTWHO_ONE_SHOT": ("oneshot", "0", store_const, True),
+        "VIRTWHO_LOG_PER_CONFIG": ("log_per_config",
+                                   DEFAULTS[VW_GLOBAL]["log_per_config"],
+                                   store_const, "true"),
+        "VIRTWHO_LOG_FILE": ("log_file",
+                             DEFAULTS[VW_GLOBAL]["log_file"],
+                             store_value),
+        "VIRTWHO_DEBUG": ("debug",
+                          DEFAULTS[VW_GLOBAL]["debug"],
+                          store_const, "true"),
+        "VIRTWHO_BACKGROUND": ("background",
+                               DEFAULTS[VW_GLOBAL]["background"],
+                               store_const,
+                               "true"),
+        "VIRTWHO_ONE_SHOT": ("oneshot",
+                             DEFAULTS[VW_GLOBAL]["oneshot"],
+                             store_const,
+                             "true"),
         "VIRTWHO_SAM": ("smType", "0", store_const, SAT6),
         "VIRTWHO_SATELLITE6": ("smType", "0", store_const, SAT6),
         "VIRTWHO_SATELLITE5": ("smType", "0", store_const, SAT5),
@@ -191,10 +210,12 @@ def read_config_env_variables(options):
         "VIRTWHO_ESX": ("virtType", "0", store_const, "esx"),
         "VIRTWHO_XEN": ("virtType", "0", store_const, "xen"),
         "VIRTWHO_RHEVM": ("virtType", "0", store_const, "rhevm"),
-        "VIRTWHO_HYPERV": ("virtType", "0", store_const, "hyperv")
+        "VIRTWHO_HYPERV": ("virtType", "0", store_const, "hyperv"),
+        "VIRTWHO_INTERVAL": ("interval", DEFAULTS[VW_GLOBAL]["interval"], store_value),
+        "VIRTWHO_REPORTER_ID": ("reporter_id", DEFAULTS[VW_GLOBAL]["reporter_id"], store_value),
     }
 
-    # Store values of environment variables to options using dispatcher
+    # Store values of environment variables to env_vars using dispatcher
     for key, values in dispatcher.items():
         attribute = values[0]
         default_value = values[1]
@@ -204,33 +225,17 @@ def read_config_env_variables(options):
         try:
             value = values[3]
         except IndexError:
-            method(options, attribute, env, default_value)
+            method(env_vars, attribute, env, default_value)
         else:
-            method(options, attribute, env, value)
+            method(env_vars, attribute, env, value)
 
-    # Some special cases is better keep out of dispatcher
-    env = os.getenv("VIRTWHO_REPORTER_ID", "").strip()
-    if len(env) > 0:
-        options.reporter_id = env
-
-    env = os.getenv("VIRTWHO_INTERVAL", "").strip()
-    if env:
-        try:
-            interval = int(env)
-            if interval >= MinimumSendInterval:
-                options.interval = interval
-            elif interval < MinimumSendInterval:
-                options.interval = MinimumSendInterval
-        except ValueError:
-            errors.append(("warning", "Interval: %s is not number, ignoring" % env))
-
-    env = os.getenv("VIRTWHO_LOG_DIR", log.DEFAULT_LOG_DIR).strip()
-    if env != log.DEFAULT_LOG_DIR:
-        options.log_dir = env
-    elif options.log_per_config:
-        options.log_dir = os.path.join(log.DEFAULT_LOG_DIR, 'virtwho')
-
-    return errors
+    # Todo: move this logic to the EffectiveConfig
+    # env = os.getenv("VIRTWHO_LOG_DIR", log.DEFAULT_LOG_DIR).strip()
+    # if env != log.DEFAULT_LOG_DIR:
+    #     env_vars.log_dir = env
+    # elif env_vars.log_per_config:
+    #     env_vars.log_dir = os.path.join(log.DEFAULT_LOG_DIR, 'virtwho')
+    return env_vars
 
 
 def check_env(variable, option, required=True):
@@ -245,43 +250,55 @@ def check_env(variable, option, required=True):
     return option
 
 
-def read_vm_backend_env_variables(logger, options):
+def read_vm_backend_env_variables(env_vars):
     """
     Try to read environment variables for virtual manager backend
     :param logger: Object used for logging
-    :param options: Dictionary with options
+    :param env_vars: Dictionary with env_vars
     :return: None
     """
-    if options.smType == SAT5:
-        options.sat_server = check_env("VIRTWHO_SATELLITE_SERVER", options.sat_server)
-        options.sat_username = check_env("VIRTWHO_SATELLITE_USERNAME", options.sat_username)
-        if len(options.sat_password) == 0:
-            options.sat_password = os.getenv("VIRTWHO_SATELLITE_PASSWORD", "")
+    errors = []
 
-    if options.smType == 'sam':
+    sm_type = env_vars.get('smType', DEFAULTS[VW_ENV_CLI_SECTION_NAME]['smtype'])
+    if sm_type is None:
+        # Just don't read the env vars if there is no smType specified
+        return env_vars, errors
+
+    if sm_type == SAT5:
+        env_vars['sat_server'] = os.getenv("VIRTWHO_SATELLITE_SERVER")
+        env_vars['sat_username'] = os.getenv("VIRTWHO_SATELLITE_USERNAME")
+        env_vars['sat_password'] = os.getenv("VIRTWHO_SATELLITE_PASSWORD")
+
+    if sm_type == SAT5:
         VM_DISPATCHER = SAM_VM_DISPATCHER
-    elif options.smType == 'satellite':
+    elif sm_type == SAT6:
         VM_DISPATCHER = SAT_VM_DISPATCHER
     else:
-        raise OptionError("Report host/guest associations was not specified.")
+        errors.append(("warning", "Env"))
+        VM_DISPATCHER = {}
 
-    if options.virtType in VM_DISPATCHER.keys():
-        virt_type = options.virtType
+    if env_vars.get('virtType') in VM_DISPATCHER.keys():
+        virt_type = env_vars['virtType']
         try:
-            options.owner = check_env("VIRTWHO_" + virt_type.upper() + "_OWNER", options.owner,
-                                      required=VM_DISPATCHER[virt_type]['owner'])
-            options.env = check_env("VIRTWHO_" + virt_type.upper() + "_ENV", options.env,
-                                    required=VM_DISPATCHER[virt_type]['env'])
-            options.server = check_env("VIRTWHO_" + virt_type.upper() + "_SERVER", options.server,
-                                       required=VM_DISPATCHER[virt_type]['server'])
-            options.username = check_env("VIRTWHO_" + virt_type.upper() + "_USERNAME", options.username,
-                                         required=VM_DISPATCHER[virt_type]['username'])
+            env_vars['owner'] = check_env("VIRTWHO_" + virt_type.upper() + "_OWNER",
+                                          env_vars.get('owner'),
+                                          required=VM_DISPATCHER[virt_type]['owner'])
+            env_vars['env'] = check_env("VIRTWHO_" + virt_type.upper() + "_ENV",
+                                        env_vars.get('env'),
+                                        required=VM_DISPATCHER[virt_type]['env'])
+            env_vars['server'] = check_env("VIRTWHO_" + virt_type.upper() + "_SERVER",
+                                           env_vars.get('server'),
+                                           required=VM_DISPATCHER[virt_type]['server'])
+            env_vars['username'] = check_env("VIRTWHO_" + virt_type.upper() + "_USERNAME",
+                                             env_vars.get('username'),
+                                             required=VM_DISPATCHER[virt_type]['username'])
         except OptionError as err:
-            logger.error("Error: reading environment variables for virt. type: %s: %s" % (options.virtType, err))
-            options.virtType = None
+            errors.append(("error", "Error: reading environment variables for virt. type: %s: %s" % (
+                env_vars.get('virtType'), err)))
         else:
-            if len(options.password) == 0:
-                options.password = os.getenv("VIRTWHO_" + virt_type.upper() + "_PASSWORD", "")
+            if len(env_vars.get('password', '')) == 0:
+                env_vars['password'] = os.getenv("VIRTWHO_" + virt_type.upper() + "_PASSWORD", "")
+    return env_vars, errors
 
 
 def parse_cli_arguments():
@@ -305,7 +322,7 @@ def parse_cli_arguments():
                         help="Send the list of guest IDs and exit immediately")
     parser.add_argument("-i", "--interval", type=int, dest="interval", default=NotSetSentinel(),
                         help="Acquire list of virtual guest each N seconds. Send if changes are detected.")
-    parser.add_argument("-p", "--print", action="store_true", dest="print_", default=False,
+    parser.add_argument("-p", "--print", action="store_true", dest="print", default=False,
                         help="Print the host/guest association obtained from virtualization backend (implies oneshot)")
     parser.add_argument("-c", "--config", action="append", dest="configs", default=[],
                         help="Configuration file that will be processed, can be used multiple times")
@@ -325,7 +342,7 @@ def parse_cli_arguments():
         description="Choose virtualization backend that should be used to gather host/guest associations"
     )
     virt_group.add_argument("--libvirt", action=StoreVirtType, dest="virtType", const="libvirt",
-                            default=None, help="Use libvirt to list virtual guests")
+                            help="Use libvirt to list virtual guests")
     virt_group.add_argument("--vdsm", action=StoreVirtType, dest="virtType", const="vdsm",
                             help="Use vdsm to list virtual guests")
     virt_group.add_argument("--esx", action=StoreVirtType, dest="virtType", const="esx",
@@ -341,7 +358,8 @@ def parse_cli_arguments():
         title="Subscription manager",
         description="Choose where the host/guest associations should be reported"
     )
-    manager_group.add_argument("--sam", action="store_const", dest="smType", const=SAT6, default=SAT6,
+    manager_group.add_argument("--sam", action="store_const", dest="smType", const=SAT6,
+                               default=NotSetSentinel(),
                                help="Report host/guest associations to the Subscription Asset Manager [default]")
     manager_group.add_argument("--satellite6", action="store_const", dest="smType", const=SAT6,
                                help="Report host/guest associations to the Satellite 6 server")
@@ -443,12 +461,16 @@ def parse_cli_arguments():
     cli_options = vars(parser.parse_args())
 
     # Final check of CLI arguments
-    check_argument_consistency(cli_options)
+    errors = check_argument_consistency(cli_options)
 
     # Get all default options
     defaults = vars(parser.parse_args([]))
 
-    return cli_options, defaults
+    def get_non_default_options(_cli_options, _defaults):
+        return dict((option, value) for option, value in _cli_options.iteritems()
+                    if _defaults.get(option, NotSetSentinel()) != value and value is not None)
+
+    return get_non_default_options(cli_options, defaults), errors
 
 
 def parse_options():
@@ -458,20 +480,20 @@ def parse_options():
     """
 
     # Read command line arguments first
-    cli_options, defaults = parse_cli_arguments()
-
-    # Read option from global config file
-    options = GlobalConfig.fromFile(VIRTWHO_GENERAL_CONF_PATH)
-
-    # Handle defaults from the command line options parser
-    options.update(**cli_options)
+    cli_options, errors = parse_cli_arguments()
 
     # Read configuration env. variables
-    errors = read_config_env_variables(options)
+    env_options = read_config_env_variables()
 
-    # It is possible to initialize logger now
-    log.init(options)
-    logger = log.getLogger(name='init', queue=False)
+    # Read environments variables for virtualization backends
+    env_options, env_errors = read_vm_backend_env_variables(env_options)
+    errors.extend(env_errors)
+    # Create the effective config that virt-who will use to run
+    effective_config = init_config(env_options, cli_options)
+    # Ensure validation errors during effective config creation are logged
+    errors.extend(effective_config.validation_messages)
+
+    logger = log.getLogger("init", queue=False)
 
     # Log pending errors
     for err in errors:
@@ -479,25 +501,4 @@ def parse_options():
         if method is not None:
             method(err[1])
 
-    def get_non_default_options(_cli_options, _defaults):
-        return dict((option, value) for option, value in _cli_options.iteritems()
-                    if _defaults.get(option, NotSetSentinel()) != value)
-
-    # Handle non-default command line options
-    options.update(**get_non_default_options(cli_options, defaults))
-
-    # Read environments variables for virtualization backends
-    read_vm_backend_env_variables(logger, options)
-
-    if not options.interval or options.interval == defaults['interval']:
-        logger.info("Interval set to the default of %d seconds.", DefaultInterval)
-        options.interval = DefaultInterval
-    elif options.interval < MinimumSendInterval:
-        logger.warning("Interval value can't be lower than {min} seconds. "
-                       "Default value of {min} seconds will be used.".format(min=MinimumSendInterval))
-        options.interval = MinimumSendInterval
-
-    if options.print_:
-        options.oneshot = True
-
-    return logger, options
+    return logger, effective_config

--- a/virtwho/virt/virt.py
+++ b/virtwho/virt/virt.py
@@ -297,7 +297,7 @@ class IntervalThread(Thread):
         self.dest = dest
         self._internal_terminate_event = Event()
         self.terminate_event = terminate_event or self._internal_terminate_event
-        self.interval = interval or config.interval or DefaultInterval
+        self.interval = interval
         self._oneshot = oneshot
         super(IntervalThread, self).__init__()
 
@@ -867,7 +867,7 @@ class Virt(IntervalThread):
         """
 
         for subcls in cls.__subclasses_list():
-            if config.type == subcls.CONFIG_TYPE:
+            if config['type'] == subcls.CONFIG_TYPE:
                 return subcls(logger, config, dest,
                               terminate_event=terminate_event,
                               interval=interval, oneshot=oneshot)

--- a/virtwho/virt/virt.py
+++ b/virtwho/virt/virt.py
@@ -29,7 +29,7 @@ import hashlib
 import re
 import fnmatch
 from virtwho.config import NotSetSentinel, Satellite5DestinationInfo, \
-    Satellite6DestinationInfo, DefaultDestinationInfo
+    Satellite6DestinationInfo, DefaultDestinationInfo, VW_GLOBAL
 from virtwho.manager import ManagerError, ManagerThrottleError, ManagerFatalError
 from virtwho import MinimumSendInterval
 
@@ -40,6 +40,7 @@ except ImportError:
     from virtwho.util import OrderedDict
 
 from virtwho import DefaultInterval
+
 
 class VirtError(Exception):
     pass
@@ -686,7 +687,7 @@ class DestinationThread(IntervalThread):
         # Send each Domain Guest List Report if necessary
         for source_key in domain_list_reports:
             report = data_to_send[source_key]
-            if not self.options.print_:
+            if not self.options[VW_GLOBAL]['print']:
                 retry = True
                 num_429_received = 0
                 while retry and not self.is_terminated():  # Retry if we encounter a 429
@@ -721,7 +722,7 @@ class DestinationThread(IntervalThread):
 
         # Terminate this thread if we have sent one report for each source
         if all_sources_handled and self._oneshot:
-                if not self.options.print_:
+                if not self.options[VW_GLOBAL]['print']:
                     self.logger.debug('At least one report for each connected source has been sent. Terminating.')
                 else:
                     self.logger.debug('All info to print has been gathered. Terminating.')
@@ -813,7 +814,7 @@ class Satellite5DestinationThread(DestinationThread):
         # Terminate this thread if we have sent one report for each source
         if all(source_key in sources_sent for source_key in self.source_keys)\
                 and self._oneshot:
-            if not self.options.print_:
+            if not self.options[VW_GLOBAL]['print']:
                 self.logger.debug('At least one report for each connected '
                                   'source has been sent. Terminating.')
             else:


### PR DESCRIPTION
* Implemented `VirtConfigSection` (subclass of ConfigSection) implementing most of validation logic from ecisting `Config` class. Logic specific for specific virtual backends were skipped. I assume this logic will be added into next subclasses.
* Implemented lot of unit test for new class
* Refactoring of `ConfigSection` and added bunch of unit tests for `ConfigSection`
* Method `validate()` is split to three methods: `_pre_validate()`,
  `_validate()` and `_post_validate()`. 'Post' and 'pre' methods
  are used for steps shared between subclasses. Method `_validate()`
  is intended for own implementation of validation in subclasses.
* Use attribute `invalidate_keys` and removed `to_remove`, because
  the `to_remove` duplicated functionality od `invalidate_keys`.
* Refactored method `_validate_configs()` as generic methods
  `_validate_list()` in `ConfigSection` and I'm reusing it in
  `VirtConfigSection` subclass
* Added support for `REQUIRED` options.