### PR TITLE
1484265: Do not replace /etc/virt-who.conf on rpm upgrade

### DIFF
--- a/virt-who.spec
+++ b/virt-who.spec
@@ -130,7 +130,7 @@ fi
 %ghost %{_sharedstatedir}/%{name}/key
 %{_datadir}/zsh/site-functions/_virt-who
 %{_sysconfdir}/virt-who.d/template.conf
-%{_sysconfdir}/virt-who.conf
+%attr(600, root, root) %config(noreplace) %{_sysconfdir}/virt-who.conf
 
 
 %changelog


### PR DESCRIPTION
The /etc/virt-who.conf file was being overwritten on virt-who rpm upgrade.
This oneliner should fix that.

See: https://bugzilla.redhat.com/show_bug.cgi?id=1485865