### PR TITLE
Libvirtd ConfigSection Subclass

### DIFF
--- a/tests/test_config_section_libvirtd.py
+++ b/tests/test_config_section_libvirtd.py
@@ -1,0 +1,285 @@
+# -*- coding: utf-8 -*-
+
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+
+"""
+Test validating of LibvirtdConfigSection
+"""
+
+from base import TestBase
+from mock import MagicMock
+import tempfile
+import os
+from binascii import hexlify
+import shutil
+
+from virtwho.password import Password
+from virtwho.config import EffectiveConfig, ConfigSection, parse_file
+from virtwho.virt.libvirtd.libvirtd import LibvirtdConfigSection
+
+MY_SECTION_NAME = 'test-libvirt'
+
+# Values used for testing VirtConfigSection
+LIBVIRT_SECTION_VALUES = {
+    'type': 'libvirt',
+    'server': 'ssh://10.0.0.101/system',
+    'env': '123456',
+    'owner': '123456',
+    'hypervisor_id': 'uuid',
+    'filter_hosts': '*.example.com'
+}
+
+LIBVIRT_SECTION_TEXT = """
+[test-libvirt]
+type = libvirt
+server = ssh://192.168.122.10
+env = 123456
+owner = 123456
+"""
+
+
+class TestLibvirtdConfigSection(TestBase):
+    """
+    Test base for testing class LibvirtdConfigSection
+    """
+
+    def __init__(self, *args, **kwargs):
+        super(TestLibvirtdConfigSection, self).__init__(*args, **kwargs)
+        self.virt_config = None
+
+    def init_virt_config_section(self):
+        """
+        Method executed before each unit test
+        """
+        self.virt_config = LibvirtdConfigSection(MY_SECTION_NAME, None)
+        # We need to set values using this way, because we need
+        # to trigger __setitem__ of virt_config
+        for key, value in LIBVIRT_SECTION_VALUES.items():
+            self.virt_config[key] = value
+
+    def test_validate_libvirt_section(self):
+        """
+        Test validation of libvirt section
+        """
+        self.init_virt_config_section()
+        result = self.virt_config.validate()
+        self.assertGreater(len(result), 0)
+
+    def test_validate_server_optional(self):
+        """
+        Test validation of server option. It is optional for libvirtd
+        """
+        self.init_virt_config_section()
+        # The server option is set
+        result = self.virt_config._validate_server()
+        self.assertIsNone(result)
+        # The server option is not set
+        del self.virt_config['server']
+        result = self.virt_config._validate_server()
+        self.assertIsNone(result)
+
+    def test_validate_server_full_url(self):
+        """
+        Test validation of libvirt URL containing all parts
+        """
+        self.init_virt_config_section()
+        # Set full URL
+        self.virt_config['server'] = 'qemu+ssh://admin@example.com/system'
+        result = self.virt_config._validate_server()
+        self.assertIsNone(result)
+
+    def test_validate_server_url_missing_path(self):
+        """
+        Test validation of libvirt URL with missing path
+        """
+        self.init_virt_config_section()
+        # Set full URL
+        self.virt_config['server'] = 'qemu+ssh://admin@example.com'
+        result = self.virt_config._validate_server()
+        expected_result = [
+            ('info', 'Libvirt path is not specified in the url, using /system')
+        ]
+        self.assertEqual(result, expected_result)
+        self.assertEqual(self.virt_config['server'], 'qemu+ssh://admin@example.com/system?no_tty=1')
+
+    def test_validate_server_url_missing_scheme(self):
+        """
+        Test validation of libvirt URL with missing scheme
+        """
+        self.init_virt_config_section()
+        # Set full URL
+        self.virt_config['server'] = 'example.com/system'
+        result = self.virt_config._validate_server()
+        expected_result = [
+            ('info', 'Protocol is not specified in libvirt url, using qemu+ssh://')
+        ]
+        self.assertEqual(result, expected_result)
+        self.assertEqual(self.virt_config['server'], 'qemu+ssh://example.com/system?no_tty=1')
+
+    def test_validate_server_url_missing_scheme_and_path(self):
+        """
+        Test validation of libvirt URL with missing scheme and path
+        """
+        self.init_virt_config_section()
+        # Set full URL
+        self.virt_config['server'] = 'example.com'
+        result = self.virt_config._validate_server()
+        expected_result = [
+            ('info', 'Protocol is not specified in libvirt url, using qemu+ssh://'),
+            ('info', 'Libvirt path is not specified in the url, using /system')
+        ]
+        self.assertEqual(result, expected_result)
+        self.assertEqual(self.virt_config['server'], 'qemu+ssh://example.com/system?no_tty=1')
+
+    def test_validate_owner(self):
+        """
+        Test validation of owner option for libvirtd virt. backend
+        """
+        self.init_virt_config_section()
+        # When server is set, then owner has to be set too
+        assert 'server' in self.virt_config
+        result = self.virt_config._validate_owner()
+        self.assertIsNone(result)
+        # Delete 'owner' section
+        del self.virt_config['owner']
+        result = self.virt_config._validate_owner()
+        self.assertIsNotNone(result)
+        # Delete server too, then owner need not to be set
+        del self.virt_config['server']
+        result = self.virt_config._validate_owner()
+        self.assertIsNone(result)
+
+    def test_validate_env(self):
+        """
+        Test validation of owner option for libvirtd virt. backend.
+        It is similar for owner
+        """
+        self.init_virt_config_section()
+        # When server is set, then owner has to be set too
+        assert 'server' in self.virt_config
+        result = self.virt_config._validate_env()
+        self.assertIsNone(result)
+        # Delete 'env' section
+        del self.virt_config['env']
+        result = self.virt_config._validate_env()
+        self.assertIsNotNone(result)
+        # Delete server too, then env need not to be set
+        del self.virt_config['server']
+        result = self.virt_config._validate_env()
+        self.assertIsNone(result)
+
+    def test_validate_unencrypted_password(self):
+        """
+        test validation of unecrypted password option for libvirt virt. backend
+        """
+        self.init_virt_config_section()
+        # Validation with no password option
+        result = self.virt_config._validate_unencrypted_password('password')
+        self.assertIsNone(result)
+        # RHSM password or RHSM proxy can be set
+        self.virt_config['rhsm_password'] = 'secret_password'
+        result = self.virt_config._validate_unencrypted_password('rhsm_password')
+        self.assertIsNone(result)
+        self.virt_config['rhsm_proxy_password'] = 'secret_password'
+        result = self.virt_config._validate_unencrypted_password('rhsm_proxy_password')
+        self.assertIsNone(result)
+        # When server is set, then setting password is useless
+        self.virt_config['password'] = 'another_secret_password'
+        result = self.virt_config._validate_unencrypted_password('password')
+        self.assertIsNotNone(result)
+        # When server is not set, then setting password is useless too, but
+        # reason is different
+        del self.virt_config['server']
+        result = self.virt_config._validate_unencrypted_password('password')
+        self.assertIsNotNone(result)
+
+    def mock_pwd_file(self):
+        # Backup previous values
+        self.old_key_file = Password.KEYFILE
+        self.old_can_write = Password._can_write
+        # Mock pwd file
+        f, filename = tempfile.mkstemp()
+        self.addCleanup(os.unlink, filename)
+        Password.KEYFILE = filename
+        Password._can_write = MagicMock(return_value=True)
+
+    def unmock_pwd_file(self):
+        # Restore pwd file from backup
+        Password.KEYFILE = self.old_key_file
+        Password._can_write = self.old_can_write
+
+    def test_validate_encrypted_password(self):
+        """
+        test validation of encrypted password option for libvirt virt. backend
+        """
+        self.mock_pwd_file()
+        self.init_virt_config_section()
+        # Validation with no encrypted_password option
+        result = self.virt_config._validate_encrypted_password('encrypted_password')
+        self.assertIsNone(result)
+        # RHSM password or RHSM proxy can be set
+        self.virt_config['rhsm_encrypted_password'] = hexlify(Password.encrypt('secret_password'))
+        result = self.virt_config._validate_encrypted_password('rhsm_encrypted_password')
+        self.assertIsNone(result)
+        self.virt_config['rhsm_encrypted_proxy_password'] = hexlify(Password.encrypt('secret_password'))
+        result = self.virt_config._validate_encrypted_password('rhsm_encrypted_proxy_password')
+        self.assertIsNone(result)
+        # When server is set, then setting password is useless
+        self.virt_config['encrypted_password'] = hexlify(Password.encrypt('another_secret_password'))
+        result = self.virt_config._validate_encrypted_password('encrypted_password')
+        self.assertIsNotNone(result)
+        # When server is not set, then setting password is useless too, but
+        # reason is different
+        del self.virt_config['server']
+        result = self.virt_config._validate_encrypted_password('encrypted_password')
+        self.assertIsNotNone(result)
+        self.unmock_pwd_file()
+
+
+class TestLibvirtEffectiveConfig(TestBase):
+    """
+    Test reading config section from text using EffectiveConfig
+    """
+
+    def __init__(self, *args, **kwargs):
+        super(TestLibvirtEffectiveConfig, self).__init__(*args, **kwargs)
+        self.effective_config = None
+
+    def init_effective_config(self):
+        """
+        This method is executed before each unit test
+        """
+        self.effective_config = EffectiveConfig()
+
+    def test_read_effective_config_from_file(self):
+        config_dir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, config_dir)
+        with open(os.path.join(config_dir, "test.conf"), "w") as f:
+            f.write(LIBVIRT_SECTION_TEXT)
+        conf = parse_file(os.path.join(config_dir, "test.conf"))
+        self.init_effective_config()
+        conf_values = conf.pop(MY_SECTION_NAME)
+        self.effective_config[MY_SECTION_NAME] = ConfigSection.from_dict(
+            conf_values,
+            MY_SECTION_NAME,
+            self.effective_config
+        )
+        self.assertEqual(type(self.effective_config[MY_SECTION_NAME]), LibvirtdConfigSection)
+        self.assertEqual(self.effective_config[MY_SECTION_NAME]['server'], 'ssh://192.168.122.10')
+        validate_messages = self.effective_config.validate()
+        self.assertIsNotNone(validate_messages)
+        del self.effective_config[MY_SECTION_NAME]

--- a/tests/test_config_section_virt.py
+++ b/tests/test_config_section_virt.py
@@ -27,7 +27,7 @@ import tempfile
 import os
 from binascii import hexlify
 
-from virtwho.config import VirtConfigSection, VW_TYPES
+from virtwho.config import VirtConfigSection, LibvirtdConfigSection, VW_TYPES
 from virtwho.password import Password
 
 
@@ -57,11 +57,25 @@ class TestVirtConfigSection(TestBase):
         """
         Method executed before each unit test
         """
-        self.virt_config = VirtConfigSection('test-libvirt', None)
+        self.virt_config = VirtConfigSection('test_libvirt', None)
         # We need to set values using this way, because we need
         # to trigger __setitem__ of virt_config
         for key, value in LIBVIRT_SECTION_VALUES.items():
             self.virt_config[key] = value
+
+    def test_virt_config_section_new(self):
+        """
+        Test creating instance of subclass of VirtConfigSection
+        """
+        virt_config = VirtConfigSection(section_name='test_libvirt', wrapper=None, virt_type='libvirt')
+        self.assertEqual(type(virt_config), LibvirtdConfigSection)
+
+    def test_virt_config_section_new_no_virt_type(self):
+        """
+        Test creating instance of VirtConfigSection without definition of virt_type
+        """
+        virt_config = VirtConfigSection(section_name='test_libvirt', wrapper=None)
+        self.assertEqual(type(virt_config), VirtConfigSection)
 
     def test_validate_virt_type(self):
         """

--- a/tests/test_effective_config.py
+++ b/tests/test_effective_config.py
@@ -27,7 +27,7 @@ import shutil
 from virtwho.config import EffectiveConfig, ConfigSection, parse_file
 
 
-MY_SECTION_NAME = 'my_test_section'
+CUSTOM_SECTION_NAME = 'my_test_section'
 
 
 CUSTOM_SECTION_VALUES = {
@@ -47,7 +47,7 @@ another_str=pub
 my_bool=false
 my_list=cat, dog, frog
 must_have=bar
-""".format(section_name=MY_SECTION_NAME)
+""".format(section_name=CUSTOM_SECTION_NAME)
 
 
 class CustomConfigSection(ConfigSection):
@@ -115,11 +115,11 @@ class TestEffectiveConfig(TestBase):
         This method is executed before each unit test
         """
         self.effective_config = EffectiveConfig()
-        self.config_section = CustomConfigSection(MY_SECTION_NAME, self.effective_config)
+        self.config_section = CustomConfigSection(CUSTOM_SECTION_NAME, self.effective_config)
         # Fill config section with some values
         for key, value in CUSTOM_SECTION_VALUES.items():
             self.config_section[key] = value
-        self.effective_config[MY_SECTION_NAME] = self.config_section
+        self.effective_config[CUSTOM_SECTION_NAME] = self.config_section
 
     def test_effective_config_validate(self):
         self.init_effective_config()
@@ -137,35 +137,35 @@ class TestEffectiveConfig(TestBase):
         self.effective_config.validate()
         virt_sections = self.effective_config.virt_sections()
         self.assertEqual(len(virt_sections), 1)
-        self.assertEqual(virt_sections[0][0], MY_SECTION_NAME)
+        self.assertEqual(virt_sections[0][0], CUSTOM_SECTION_NAME)
 
     def test_effective_config_is_value_default(self):
         self.init_effective_config()
         self.effective_config.validate()
-        result = self.effective_config.is_default(MY_SECTION_NAME, 'my_str')
+        result = self.effective_config.is_default(CUSTOM_SECTION_NAME, 'my_str')
         self.assertEqual(result, False)
-        result = self.effective_config.is_default(MY_SECTION_NAME, 'another_str')
+        result = self.effective_config.is_default(CUSTOM_SECTION_NAME, 'another_str')
         self.assertEqual(result, True)
 
     def test_effective_config_items(self):
         self.init_effective_config()
         self.effective_config.validate()
         for key, item in self.effective_config.items():
-            self.assertEqual(key, MY_SECTION_NAME)
+            self.assertEqual(key, CUSTOM_SECTION_NAME)
             self.assertEqual(type(item), CustomConfigSection)
 
     def test_effective_config_del_item(self):
         self.init_effective_config()
         self.effective_config.validate()
         self.assertEqual(len(self.effective_config), 1)
-        del self.effective_config[MY_SECTION_NAME]
+        del self.effective_config[CUSTOM_SECTION_NAME]
         self.assertEqual(len(self.effective_config), 0)
 
     def test_effective_config_is_singleton(self):
         self.init_effective_config()
         self.effective_config.validate()
         effective_config = EffectiveConfig()
-        self.assertIn(MY_SECTION_NAME, effective_config)
+        self.assertIn(CUSTOM_SECTION_NAME, effective_config)
 
     def test_effective_config_filter_params(self):
         effective_config = EffectiveConfig()
@@ -193,13 +193,13 @@ class TestEffectiveConfig(TestBase):
             f.write(CONFIG_SECTION_TEXT)
         conf = parse_file(os.path.join(config_dir, "test.conf"))
         effective_config = EffectiveConfig()
-        conf_values = conf.pop(MY_SECTION_NAME)
-        effective_config[MY_SECTION_NAME] = ConfigSection.from_dict(
+        conf_values = conf.pop(CUSTOM_SECTION_NAME)
+        effective_config[CUSTOM_SECTION_NAME] = ConfigSection.from_dict(
             conf_values,
-            MY_SECTION_NAME,
+            CUSTOM_SECTION_NAME,
             effective_config
         )
-        self.assertEqual(type(effective_config[MY_SECTION_NAME]), CustomConfigSection)
-        self.assertEqual(effective_config[MY_SECTION_NAME]['my_str'], 'foo')
+        self.assertEqual(type(effective_config[CUSTOM_SECTION_NAME]), CustomConfigSection)
+        self.assertEqual(effective_config[CUSTOM_SECTION_NAME]['my_str'], 'foo')
         validate_messages = effective_config.validate()
         self.assertEqual(validate_messages, [])

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -110,7 +110,7 @@ class TestSubscriptionManager(TestManager):
                     ]
                 )
                 for host in self.host_guest_report.association['hypervisors']),
-            options=self.options)
+            options=ANY)
 
 
 class TestSatellite(TestManager):

--- a/tests/test_virtwho.py
+++ b/tests/test_virtwho.py
@@ -115,7 +115,7 @@ class TestOptions(TestBase):
         self.setUpParseFile(parseFile)
         sys.argv = ["virtwho.py", "--libvirt-username=admin", "--libvirt"]
         _, options = parse_options()
-        self.assertEqual(options[VW_ENV_CLI_SECTION_NAME]['virttype'], "libvirt")
+        self.assertEqual(options[VW_ENV_CLI_SECTION_NAME]['type'], "libvirt")
         self.assertEqual(options[VW_ENV_CLI_SECTION_NAME]['username'], "admin")
 
     @patch('virtwho.log.getLogger')
@@ -176,7 +176,7 @@ class TestOptions(TestBase):
                         "--%s-username=username" % virt,
                         "--%s-password=password" % virt]
             _, options = parse_options()
-            self.assertEqual(options[VW_ENV_CLI_SECTION_NAME]['virttype'], virt)
+            self.assertEqual(options[VW_ENV_CLI_SECTION_NAME]['type'], virt)
             self.assertEqual(options[VW_ENV_CLI_SECTION_NAME]['owner'], 'owner')
             self.assertEqual(options[VW_ENV_CLI_SECTION_NAME]['env'], 'env')
             self.assertEqual(options[VW_ENV_CLI_SECTION_NAME]['server'], 'localhost')
@@ -192,7 +192,7 @@ class TestOptions(TestBase):
             os.environ["VIRTWHO_%s_USERNAME" % virt_up] = "xusername"
             os.environ["VIRTWHO_%s_PASSWORD" % virt_up] = "xpassword"
             _, options = parse_options()
-            self.assertEqual(options[VW_ENV_CLI_SECTION_NAME]['virttype'], virt)
+            self.assertEqual(options[VW_ENV_CLI_SECTION_NAME]['type'], virt)
             self.assertEqual(options[VW_ENV_CLI_SECTION_NAME]['owner'], 'xowner')
             self.assertEqual(options[VW_ENV_CLI_SECTION_NAME]['env'], 'xenv')
             self.assertEqual(options[VW_ENV_CLI_SECTION_NAME]['server'], 'xlocalhost')
@@ -215,7 +215,7 @@ class TestOptions(TestBase):
                         "--%s-username=username" % virt,
                         "--%s-password=password" % virt]
             _, options = parse_options()
-            self.assertEqual(options[VW_ENV_CLI_SECTION_NAME]['virttype'], virt)
+            self.assertEqual(options[VW_ENV_CLI_SECTION_NAME]['type'], virt)
             self.assertEqual(options[VW_ENV_CLI_SECTION_NAME]['server'], 'localhost')
             self.assertEqual(options[VW_ENV_CLI_SECTION_NAME]['username'], 'username')
             self.assertEqual(options[VW_ENV_CLI_SECTION_NAME]['password'], 'password')
@@ -233,7 +233,7 @@ class TestOptions(TestBase):
             os.environ["VIRTWHO_%s_USERNAME" % virt_up] = "xusername"
             os.environ["VIRTWHO_%s_PASSWORD" % virt_up] = "xpassword"
             _, options = parse_options()
-            self.assertEqual(options[VW_ENV_CLI_SECTION_NAME]['virttype'], virt)
+            self.assertEqual(options[VW_ENV_CLI_SECTION_NAME]['type'], virt)
             self.assertEqual(options[VW_ENV_CLI_SECTION_NAME]['server'], 'xlocalhost')
             self.assertEqual(options[VW_ENV_CLI_SECTION_NAME]['owner'], 'xowner')
             self.assertEqual(options[VW_ENV_CLI_SECTION_NAME]['env'], 'xenv')

--- a/virtwho/config.py
+++ b/virtwho/config.py
@@ -27,7 +27,6 @@ from binascii import unhexlify
 import hashlib
 import json
 import util
-import urlparse
 
 # Module-level logger
 logger = log.getLogger('config', queue=False)
@@ -1434,8 +1433,10 @@ class EffectiveConfig(collections.MutableMapping):
         for param, value in values_to_filter.iteritems():
             if value is None:
                 continue
-            if not hasattr(value, '__iter__'):
-                str(value)
+            if type(value) is list:
+                value = [str(item) for item in value]
+            else:
+                value = str(value)
             if param in desired_parameters:
                 matching_parameters[param] = value
             else:
@@ -1504,7 +1505,6 @@ def _check_effective_config_validity(effective_config):
             if name == VW_GLOBAL:
                 # Always keep the global section
                 continue
-            # FIXME: why is env/cli automatically dropped?
             if name == VW_ENV_CLI_SECTION_NAME:
                 has_non_default_env_cli = True
             validation_errors.append(('warning', 'Dropping invalid configuration "%s"' % name))

--- a/virtwho/config.py
+++ b/virtwho/config.py
@@ -27,6 +27,7 @@ from binascii import unhexlify
 import hashlib
 import json
 import util
+import urlparse
 
 # Module-level logger
 logger = log.getLogger('config', queue=False)
@@ -669,6 +670,7 @@ def parse_file(filename):
     # options_dict is a dict of option_name: value
     parser = StripQuotesConfigParser()
     sections = {}
+
     try:
         fname = parser.read(filename)
         if len(fname) == 0:
@@ -961,18 +963,29 @@ class ConfigSection(collections.MutableMapping):
         return defaults
 
     @classmethod
-    def class_for_type(cls, virt_type):
-        clazz = cls
+    def class_for_type(cls, virt_type, parent=None):
+        if parent is None:
+            clazz = cls
+        else:
+            clazz = parent
         for subclass in cls.__subclasses__():
             if getattr(subclass, 'VIRT_TYPE', None) == virt_type:
                 clazz = subclass
                 break
+            # When VIRT_TYPE was not found in this subclass, then
+            # this subclass can have another subclasses :-)
+            else:
+                result = subclass.class_for_type(virt_type, cls)
+                if result != cls:
+                    clazz = result
+                    break
         return clazz
 
     @classmethod
     def from_dict(cls, values, section_name, wrapper):
         virt_type = values.get('virttype', None) or values.get('type')
-        section = cls.class_for_type(virt_type)(section_name, wrapper)
+        sub_cls = cls.class_for_type(virt_type)
+        section = sub_cls(section_name, wrapper)
         section.update(**values)
         return section
 
@@ -1059,8 +1072,26 @@ class VirtConfigSection(ConfigSection):
         ('exclude_host_uuids', 'exclude_hosts'),
     )
 
-    def __init__(self, section_name, wrapper):
+    def __new__(cls, section_name, wrapper, virt_type=None, *args, **kwargs):
+        """
+        Try to return instance of subclass specific for virtualization
+        backend specified in virt_type
+        """
+
+        # Go through all subclasses and try to find subclass with the
+        # same virt_type
+        if virt_type is not None:
+            for sub_cls in cls.__subclasses__():
+                if hasattr(sub_cls, 'VIRT_TYPE') and sub_cls.VIRT_TYPE == virt_type:
+                    # Return instance of subclass
+                    return super(VirtConfigSection, sub_cls).__new__(sub_cls)
+        # Subclass with virt_type was not implemented yet or was not specified
+        # Returning instance of VirtConfigSection
+        return super(VirtConfigSection, cls).__new__(cls)
+
+    def __init__(self, section_name, wrapper, virt_type=None):
         super(VirtConfigSection, self).__init__(section_name, wrapper)
+        self._values['type'] = virt_type
 
     def __setitem__(self, key, value):
         for old_key, new_key in self.RENAMED_OPTIONS:
@@ -1108,7 +1139,7 @@ class VirtConfigSection(ConfigSection):
         """
         Try to validate encrypted password. It has to be UTF-8 encoded.
         :param pass_key: This could be: 'encrypted_password', 'rhsm_encrypted_password',
-                         'rhsm_proxy_encrypted_password' and 'sat_encrypted_password'
+                         'rhsm_encrypted_proxy_password' and 'sat_encrypted_password'
         """
         result = None
         decrypted_pass_key = self.PASSWORD_OPTIONS[pass_key]
@@ -1179,9 +1210,7 @@ class VirtConfigSection(ConfigSection):
         result = None
         sm_type = self._values['sm_type']
         virt_type = self._values['type']
-        if sm_type == 'sam' and (
-                (virt_type in ('esx', 'rhevm', 'hyperv', 'xen')) or
-                (virt_type == 'libvirt' and 'server' in self._values)):
+        if sm_type == 'sam' and virt_type in ('esx', 'rhevm', 'hyperv', 'xen'):
             if 'env' not in self:
                 result = (
                     'warning',
@@ -1196,9 +1225,7 @@ class VirtConfigSection(ConfigSection):
         result = None
         sm_type = self._values['sm_type']
         virt_type = self._values['type']
-        if sm_type == 'sam' and (
-                (virt_type in ('esx', 'rhevm', 'hyperv', 'xen')) or
-                (virt_type == 'libvirt' and 'server' in self._values)):
+        if sm_type == 'sam' and virt_type in ('esx', 'rhevm', 'hyperv', 'xen'):
             if 'owner' not in self:
                 result = (
                     'warning',
@@ -1225,6 +1252,9 @@ class VirtConfigSection(ConfigSection):
             'encrypted_rhsm_proxy_password': (self._validate_encrypted_password, ('rhsm_proxy_encrypted_password',)),
             'encrypted_sat_password': (self._validate_encrypted_password, ('sat_encrypted_password',)),
             'username': (self._validate_username, ('username',)),
+            'rhsm_hostname': (self._validate_non_empty_string, ('rhsm_hostname',)),
+            'rhsm_port': (self._validate_non_empty_string, ('rhsm_port',)),
+            'rhsm_prefix': (self._validate_non_empty_string, ('rhsm_prefix',)),
             'rhsm_username': (self._validate_username, ('rhsm_username',)),
             'rhsm_proxy_username': (self._validate_username, ('rhsm_proxy_username',)),
             'sat_username': (self._validate_username, ('sat_username',)),
@@ -1404,7 +1434,8 @@ class EffectiveConfig(collections.MutableMapping):
         for param, value in values_to_filter.iteritems():
             if value is None:
                 continue
-            value = str(value)
+            if not hasattr(value, '__iter__'):
+                str(value)
             if param in desired_parameters:
                 matching_parameters[param] = value
             else:
@@ -1473,12 +1504,13 @@ def _check_effective_config_validity(effective_config):
             if name == VW_GLOBAL:
                 # Always keep the global section
                 continue
+            # FIXME: why is env/cli automatically dropped?
             if name == VW_ENV_CLI_SECTION_NAME:
                 has_non_default_env_cli = True
             validation_errors.append(('warning', 'Dropping invalid configuration "%s"' % name))
             del effective_config[name]
         validation_errors.append(('warning',
-                                  'Using default "%s" configuration' % VW_ENV_CLI_SECTION_NAME))
+                                  'Using default "%s" configuration' % name))
         # In order to keep compatibility with older releases of virt-who,
         # fallback to using libvirt as default virt backend
         # only if we did not have a non_default env/cmdline config

--- a/virtwho/manager/subscriptionmanager/subscriptionmanager.py
+++ b/virtwho/manager/subscriptionmanager/subscriptionmanager.py
@@ -50,6 +50,13 @@ STATE_MAPPING = {
 }
 
 
+class NamedOptions(object):
+    """
+    Object used for compatibility with RHSM
+    """
+    pass
+
+
 class SubscriptionManager(Manager):
     smType = "sam"
 
@@ -181,13 +188,19 @@ class SubscriptionManager(Manager):
         serialized_mapping = self._hypervisor_mapping(report, is_async, connection)
         self.logger.debug("Host-to-guest mapping: %s", json.dumps(serialized_mapping, indent=4))
 
+        # All subclasses of ConfigSection use dictionary like notation,
+        # but RHSM uses attribute like notation
+        named_options = NamedOptions()
+        for key, value in options['global'].items():
+            setattr(named_options, key, value)
+
         try:
             try:
                 result = self.connection.hypervisorCheckIn(
                     report.config.owner,
                     report.config.env,
                     serialized_mapping,
-                    options=options)  # pylint:disable=unexpected-keyword-arg
+                    options=named_options)  # pylint:disable=unexpected-keyword-arg
             except TypeError:
                 # This is temporary workaround until the options parameter gets implemented
                 # in python-rhsm

--- a/virtwho/virt/virt.py
+++ b/virtwho/virt/virt.py
@@ -262,12 +262,12 @@ class HostGuestAssociationReport(AbstractVirtReport):
         logger = logging.getLogger("virtwho")
         assoc = []
         for host in self._assoc['hypervisors']:
-            if self.exclude_hosts is not None and self._filter(
+            if self.exclude_hosts is not None and self.exclude_hosts != NotSetSentinel and self._filter(
                     host.hypervisorId, self.exclude_hosts):
                 logger.debug("Skipping host '%s' because its uuid is excluded", host.hypervisorId)
                 continue
 
-            if self.filter_hosts is not None and not self._filter(
+            if self.filter_hosts is not None and self.filter_hosts != NotSetSentinel and not self._filter(
                     host.hypervisorId,self.filter_hosts):
                 logger.debug("Skipping host '%s' because its uuid is not included", host.hypervisorId)
                 continue


### PR DESCRIPTION
* Implement subclass of VirtConfigSection used for validation
  options and combination of options specific for libvirtd
  virtualization backend
* Moved some validation from VirtConfigSection to
  LibvirtdConfigSection. Ported remaining libvirtd validation
  from `chechOptions` of old `Config` class.
* Improved method `class_for_type` to search recursively for
  subclasses in subclasses of ConfigSection.
* Implemented `__new__()` method fot VirtConfigSection to
  return instances of VirtConfigSection subclasses with
  required `virt_type`, but it is not used anywhere ATM.
* Added several unit tests