### PR TITLE
Adds FakeVirtConfigSection

### DIFF
--- a/tests/test_config_section_global.py
+++ b/tests/test_config_section_global.py
@@ -123,10 +123,11 @@ class TestGlobalConfigSection(TestBase):
         """
         self.init_global_config_section()
         self.global_config['interval'] = '10'
-        result = self.global_config._validate_interval('interval')
-        self.assertIsNotNone(result)
+        self.global_config.validate()
         interval = self.global_config.get('interval')
-        self.assertEqual(interval, MinimumSendInterval)
+        # The behavior of this has changed. We now replace any invalid value with the default
+        # No special cases
+        self.assertEqual(interval, DefaultInterval)
 
     def test_validate_missing_interval(self):
         """

--- a/tests/test_config_section_virt.py
+++ b/tests/test_config_section_virt.py
@@ -27,7 +27,8 @@ import tempfile
 import os
 from binascii import hexlify
 
-from virtwho.config import VirtConfigSection, LibvirtdConfigSection, VW_TYPES
+from virtwho.config import VirtConfigSection, VW_TYPES
+from virtwho.virt.libvirtd.libvirtd import LibvirtdConfigSection
 from virtwho.password import Password
 
 
@@ -63,20 +64,6 @@ class TestVirtConfigSection(TestBase):
         for key, value in LIBVIRT_SECTION_VALUES.items():
             self.virt_config[key] = value
 
-    def test_virt_config_section_new(self):
-        """
-        Test creating instance of subclass of VirtConfigSection
-        """
-        virt_config = VirtConfigSection(section_name='test_libvirt', wrapper=None, virt_type='libvirt')
-        self.assertEqual(type(virt_config), LibvirtdConfigSection)
-
-    def test_virt_config_section_new_no_virt_type(self):
-        """
-        Test creating instance of VirtConfigSection without definition of virt_type
-        """
-        virt_config = VirtConfigSection(section_name='test_libvirt', wrapper=None)
-        self.assertEqual(type(virt_config), VirtConfigSection)
-
     def test_validate_virt_type(self):
         """
         Test validation of supported types of virtualization backends
@@ -86,7 +73,7 @@ class TestVirtConfigSection(TestBase):
         test_virt_types.extend(['vmware,' 'kvm'])
         for virt_type in test_virt_types:
             self.virt_config['type'] = virt_type
-            result = self.virt_config._validate_virt_type()
+            result = self.virt_config._validate_virt_type('type')
             if virt_type not in VW_TYPES:
                 self.assertIsNotNone(result)
             else:
@@ -110,7 +97,7 @@ class TestVirtConfigSection(TestBase):
         """
         self.init_virt_config_section()
         self.virt_config['type'] = 'qemu'
-        result = self.virt_config._validate_virt_type()
+        result = self.virt_config._validate_virt_type('type')
         self.assertIsNotNone(result)
         self.virt_config.validate()
         virt_type = self.virt_config.get('type')
@@ -229,7 +216,7 @@ class TestVirtConfigSection(TestBase):
         Test validation of server
         """
         self.init_virt_config_section()
-        result = self.virt_config._validate_server()
+        result = self.virt_config._validate_server('server')
         self.assertIsNone(result)
 
     def test_validate_missing_server(self):
@@ -244,7 +231,7 @@ class TestVirtConfigSection(TestBase):
         # Test all of them
         for virt_type in virt_backends_requiring_server:
             self.virt_config['type'] = virt_type
-            result = self.virt_config._validate_server()
+            result = self.virt_config._validate_server('server')
             self.assertIsNotNone(result)
 
     def test_validate_missing_server_not_critical(self):
@@ -260,7 +247,7 @@ class TestVirtConfigSection(TestBase):
         # Test all of vm backend types
         for virt_type in virt_backends_not_requiring_server:
             self.virt_config['type'] = virt_type
-            result = self.virt_config._validate_server()
+            result = self.virt_config._validate_server('server')
             self.assertIsNone(result)
 
     def test_validate_environment(self):
@@ -268,7 +255,7 @@ class TestVirtConfigSection(TestBase):
         Test validation of env option 
         """
         self.init_virt_config_section()
-        result = self.virt_config._validate_env()
+        result = self.virt_config._validate_env('env')
         self.assertIsNone(result)
 
     def test_validate_owner(self):
@@ -276,7 +263,7 @@ class TestVirtConfigSection(TestBase):
         Test validation of owner option
         """
         self.init_virt_config_section()
-        result = self.virt_config._validate_owner()
+        result = self.virt_config._validate_owner('owner')
         self.assertIsNone(result)
 
     def test_validate_filter(self):

--- a/tests/test_datastore.py
+++ b/tests/test_datastore.py
@@ -7,11 +7,11 @@ from virtwho.datastore import Datastore
 class TestDatastore(TestBase):
 
     def setUp(self):
-        pickle_patcher = patch('virtwho.datastore.pickle')
-        self.mock_pickle = pickle_patcher.start()
-        self.mock_pickle.dumps.return_value = sentinel.pickled_value
-        self.mock_pickle.loads.return_value = sentinel.unpickled_value
-        self.addCleanup(pickle_patcher.stop)
+        copy_patcher = patch('virtwho.datastore.copy')
+        self.mock_copy = copy_patcher.start()
+        self.mock_copy.deepcopy.side_effect = [sentinel.deep_copy_value_1,
+                                                sentinel.deep_copy_value_2]
+        self.addCleanup(copy_patcher.stop)
 
         lock_patcher = patch('virtwho.datastore.Lock')
         mock_lock_class = lock_patcher.start()
@@ -20,7 +20,7 @@ class TestDatastore(TestBase):
         self.mock_lock = mock_lock_instance
         self.addCleanup(lock_patcher.stop)
 
-    def mock_test_data(self, datastore, **kwargs):
+    def _mock_test_data(self, datastore, **kwargs):
         # Sets the datastore to contain the keys and values of the kwargs
         # in a way that does not use the put method of the datastore
         # Returns the datastore instance as modified, the test internal
@@ -39,7 +39,7 @@ class TestDatastore(TestBase):
         # and that the lock (when used as a context manager) is acquired by
         # the calling thread on __enter__ and released by the calling thread
         # on __exit__
-        datastore, mock_internal_datastore = self.mock_test_data(Datastore(),
+        datastore, mock_internal_datastore = self._mock_test_data(Datastore(),
                                                                  test_item=sentinel.test_value)
 
         def assert_internal_store_unchanged(*args, **kwargs):
@@ -85,7 +85,7 @@ class TestDatastore(TestBase):
         # and the item exists
         datastore = Datastore()
         expected_value = sentinel.test_value
-        self.mock_pickle.loads.side_effect = lambda x: x
+        self.mock_copy.deepcopy.side_effect = lambda x: x
         with patch.dict(datastore._datastore, test_item=expected_value):
             result = datastore.get("test_item", default=sentinel.default_value)
             self.assertEquals(result, expected_value)
@@ -98,8 +98,8 @@ class TestDatastore(TestBase):
         with patch.dict(datastore._datastore,
                         test_item=sentinel.test_item_value):
             result = datastore.get("test_item")
-        self.mock_pickle.loads.assert_called_with(sentinel.test_item_value)
-        self.assertEquals(result, self.mock_pickle.loads.return_value)
+        self.mock_copy.deepcopy.assert_called_with(sentinel.test_item_value)
+        self.assertEquals(result, sentinel.deep_copy_value_1)
 
     def test_put_locking(self):
         # Ensure that a lock is acquired before (and released after) updating a
@@ -108,7 +108,7 @@ class TestDatastore(TestBase):
         # and that the lock (when used as a context manager) is acquired by
         # the calling thread on __enter__ and released by the calling thread
         # on __exit__
-        datastore, mock_internal_datastore = self.mock_test_data(Datastore(),
+        datastore, mock_internal_datastore = self._mock_test_data(Datastore(),
                                                                  test_item=sentinel.test_value)
 
         def assert_internal_store_unchanged(*args, **kwargs):
@@ -118,7 +118,7 @@ class TestDatastore(TestBase):
 
         def assert_internal_store_accessed(*args, **kwargs):
             mock_internal_datastore.__setitem__.assert_called_once_with(
-                    "test_item", self.mock_pickle.dumps.return_value)
+                    "test_item", sentinel.deep_copy_value_1)
 
         self.mock_lock.__enter__.side_effect = assert_internal_store_unchanged
         self.mock_lock.__exit__.side_effect = assert_internal_store_accessed
@@ -127,14 +127,14 @@ class TestDatastore(TestBase):
         self.mock_lock.__enter__.assert_called_once()
         self.mock_lock.__exit__.assert_called_once()
 
-    def test_put_uses_pickle_dumps(self):
+    def test_put_uses_deepcopy(self):
         # Ensure that put uses the return value of pickle.dumps
         test_item = "test_value"
         test_key = "test_item"
-        datastore, mock_internal_ds = self.mock_test_data(Datastore(),
+        datastore, mock_internal_ds = self._mock_test_data(Datastore(),
                                                           test_item=test_item)
         datastore.put(test_key, test_item)
-        self.mock_pickle.dumps.assert_called_with(test_item)
-        expected_value = self.mock_pickle.dumps.return_value
+        self.mock_copy.deepcopy.assert_called_with(test_item)
+        expected_value = sentinel.deep_copy_value_1
         mock_internal_ds.__setitem__.assert_called_with(test_key,
                                                         expected_value)

--- a/tests/test_fake.py
+++ b/tests/test_fake.py
@@ -25,7 +25,7 @@ import shutil
 
 from base import TestBase
 
-from virtwho.config import DestinationToSourceMapper
+from virtwho.config import DestinationToSourceMapper, init_config
 from virtwho.virt import Virt, Hypervisor, VirtError
 from virtwho.virt.fakevirt import FakeVirt
 
@@ -88,10 +88,10 @@ type=fake
 is_hypervisor=true
 file=%s
 """ % self.hypervisor_file)
-
-        manager = DestinationToSourceMapper(self.logger, self.config_dir)
+        effective_config = init_config({}, {}, config_dir=self.config_dir)
+        manager = DestinationToSourceMapper(effective_config)
         self.assertEquals(len(manager.configs), 1)
-        virt = Virt.from_config(self.logger, manager.configs[0], None)
+        virt = Virt.from_config(self.logger, manager.configs[0][1], None)
         self.assertEquals(type(virt), FakeVirt)
         mapping = virt.getHostGuestMapping()
         self.assertTrue("hypervisors" in mapping)
@@ -116,12 +116,11 @@ type=fake
 is_hypervisor=true
 file=%s
 """ % self.hypervisor_file)
-
-        manager = DestinationToSourceMapper(self.logger, self.config_dir)
-        self.assertEquals(len(manager.configs), 1)
-        virt = Virt.from_config(self.logger, manager.configs[0], None)
-        self.assertEquals(type(virt), FakeVirt)
-        self.assertRaises(VirtError, virt.getHostGuestMapping)
+        effective_config = init_config({}, {}, config_dir=self.config_dir)
+        manager = DestinationToSourceMapper(effective_config)
+        # The 'test' section is not valid here (as the json provided will not work with
+        # the is_hypervisor value set to true)
+        self.assertNotIn('test', effective_config)
 
     def test_read_non_hypervisor(self):
         with open(self.hypervisor_file, "w") as f:
@@ -135,9 +134,10 @@ is_hypervisor=false
 file=%s
 """ % self.hypervisor_file)
 
-        manager = DestinationToSourceMapper(self.logger, self.config_dir)
+        effective_config = init_config({}, {}, config_dir=self.config_dir)
+        manager = DestinationToSourceMapper(effective_config)
         self.assertEquals(len(manager.configs), 1)
-        virt = Virt.from_config(self.logger, manager.configs[0], None)
+        virt = Virt.from_config(self.logger, manager.configs[0][1], None)
         self.assertEquals(type(virt), FakeVirt)
         guests = virt.listDomains()
         self.assertEquals(len(guests), 1)
@@ -157,8 +157,6 @@ is_hypervisor=false
 file=%s
 """ % self.hypervisor_file)
 
-        manager = DestinationToSourceMapper(self.logger, self.config_dir)
-        self.assertEquals(len(manager.configs), 1)
-        virt = Virt.from_config(self.logger, manager.configs[0], None)
-        self.assertEquals(type(virt), FakeVirt)
-        self.assertRaises(VirtError, virt.listDomains)
+        effective_config = init_config({}, {}, config_dir=self.config_dir)
+        # This is an invalid case, the config section that is invalid should have been dropped
+        self.assertNotIn('test', effective_config)

--- a/tests/test_hyperv.py
+++ b/tests/test_hyperv.py
@@ -27,8 +27,8 @@ import requests
 from base import TestBase
 from proxy import Proxy
 
-from virtwho.config import Config
-from virtwho.virt.hyperv import HyperV
+from virtwho import DefaultInterval
+from virtwho.virt.hyperv.hyperv import HyperV, HypervConfigSection
 from virtwho.virt import VirtError, Guest, Hypervisor
 
 
@@ -136,9 +136,18 @@ class HyperVMock(object):
 
 class TestHyperV(TestBase):
     def setUp(self):
-        config = Config('test', 'hyperv', server='localhost', username='username',
-                        password='password', owner='owner', env='env')
-        self.hyperv = HyperV(self.logger, config, None)
+        config_values = {
+            'type': 'hyperv',
+            'server': 'localhost',
+            'username': 'username',
+            'password': 'password',
+            'owner': 'owner',
+            'env': 'env,'
+        }
+        config = HypervConfigSection('test', None)
+        config.update(**config_values)
+        config.validate()
+        self.hyperv = HyperV(self.logger, config, None, interval=DefaultInterval)
 
     def run_once(self, queue=None):
         ''' Run Hyper-V in oneshot mode '''
@@ -217,7 +226,7 @@ class TestHyperV(TestBase):
             guestIds=[
                 Guest(
                     expected_guestId,
-                    self.hyperv,
+                    self.hyperv.CONFIG_TYPE,
                     expected_guest_state,
                 )
             ],

--- a/tests/test_libvirtd.py
+++ b/tests/test_libvirtd.py
@@ -19,11 +19,11 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 """
 
 from threading import Event
-from Queue import Queue
 from base import TestBase
 from mock import patch, ANY, Mock
 
-from virtwho.config import Config
+from virtwho import DefaultInterval
+from virtwho.virt.libvirtd.libvirtd import LibvirtdConfigSection
 from virtwho.datastore import Datastore
 from virtwho.virt import Virt, VirtError
 
@@ -41,8 +41,15 @@ class TestLibvirtd(TestBase):
     def setUp(self):
         pass
 
+    def create_config(self, name, wrapper, **kwargs):
+        config = LibvirtdConfigSection(name, wrapper)
+        config.update(**kwargs)
+        config.validate()
+        return config
+
     def run_virt(self, config, datastore=None):
-        v = Virt.from_config(self.logger, config, datastore or Datastore())
+        v = Virt.from_config(self.logger, config, datastore or Datastore(),
+                             interval=DefaultInterval)
         v._terminate_event = Event()
         v._interval = 3600
         v._oneshot = True
@@ -51,7 +58,7 @@ class TestLibvirtd(TestBase):
 
     @patch('libvirt.openReadOnly')
     def test_read(self, virt):
-        config = Config('test', 'libvirt')
+        config = self.create_config('test', None, type='libvirt')
         virt.return_value.getCapabilities.return_value = LIBVIRT_CAPABILITIES_XML
         virt.return_value.getType.return_value = "LIBVIRT_TYPE"
         virt.return_value.getVersion.return_value = "VERSION 1337"
@@ -60,13 +67,13 @@ class TestLibvirtd(TestBase):
 
     @patch('libvirt.openReadOnly')
     def test_read_fail(self, virt):
-        config = Config('test', 'libvirt')
+        config = self.create_config('test', None, type='libvirt')
         virt.side_effect = raiseLibvirtError
         self.assertRaises(VirtError, self.run_virt, config)
 
     @patch('libvirt.openReadOnly')
     def test_remote_hostname(self, virt):
-        config = Config('test', 'libvirt', server='server')
+        config = self.create_config('test', None, type='libvirt', server='server')
         virt.return_value.getCapabilities.return_value = LIBVIRT_CAPABILITIES_XML
         virt.return_value.getType.return_value = "LIBVIRT_TYPE"
         virt.return_value.getVersion.return_value = "VERSION 1337"
@@ -75,7 +82,7 @@ class TestLibvirtd(TestBase):
 
     @patch('libvirt.openReadOnly')
     def test_remote_url(self, virt):
-        config = Config('test', 'libvirt', server='abc://server/test')
+        config = self.create_config('test', None, type='libvirt', server='abc://server/test')
         virt.return_value.getCapabilities.return_value = LIBVIRT_CAPABILITIES_XML
         virt.return_value.getType.return_value = "LIBVIRT_TYPE"
         virt.return_value.getVersion.return_value = "VERSION 1337"
@@ -84,7 +91,7 @@ class TestLibvirtd(TestBase):
 
     @patch('libvirt.openReadOnly')
     def test_remote_hostname_with_username(self, virt):
-        config = Config('test', 'libvirt', server='server', username='user')
+        config = self.create_config('test', None, type='libvirt', server='server', username='user')
         virt.return_value.getCapabilities.return_value = LIBVIRT_CAPABILITIES_XML
         virt.return_value.getType.return_value = "LIBVIRT_TYPE"
         virt.return_value.getVersion.return_value = "VERSION 1337"
@@ -93,7 +100,7 @@ class TestLibvirtd(TestBase):
 
     @patch('libvirt.openReadOnly')
     def test_remote_url_with_username(self, virt):
-        config = Config('test', 'libvirt', server='abc://server/test',
+        config = self.create_config('test', None, type='libvirt', server='abc://server/test',
                         username='user')
         virt.return_value.getCapabilities.return_value = LIBVIRT_CAPABILITIES_XML
         virt.return_value.getType.return_value = "LIBVIRT_TYPE"
@@ -103,17 +110,18 @@ class TestLibvirtd(TestBase):
 
     @patch('libvirt.openAuth')
     def test_remote_hostname_with_username_and_password(self, virt):
-        config = Config('test', 'libvirt', server='server',
+        config = self.create_config('test', None, type='libvirt', server='server',
                         username='user', password='pass')
         virt.return_value.getCapabilities.return_value = LIBVIRT_CAPABILITIES_XML
         virt.return_value.getType.return_value = "LIBVIRT_TYPE"
         virt.return_value.getVersion.return_value = "VERSION 1337"
         self.run_virt(config)
-        virt.assert_called_with('qemu+ssh://user@server/system?no_tty=1', ANY, ANY)
+        # We don't yet support using a password with ssh
+        virt.assert_called_with('qemu://user@server/system?no_tty=1', ANY, ANY)
 
     @patch('libvirt.openAuth')
     def test_remote_url_with_username_and_password(self, virt):
-        config = Config('test', 'libvirt', server='abc://server/test',
+        config = self.create_config('test', None, type='libvirt', server='abc://server/test',
                         username='user', password='pass')
         virt.return_value.getCapabilities.return_value = LIBVIRT_CAPABILITIES_XML
         virt.return_value.getType.return_value = "LIBVIRT_TYPE"
@@ -123,7 +131,7 @@ class TestLibvirtd(TestBase):
 
     @patch('libvirt.openReadOnly')
     def test_mapping_has_hostname_when_availible(self, virt):
-        config = Config('test', 'libvirt', server='abc://server/test')
+        config = self.create_config('test', None, type='libvirt', server='abc://server/test')
         datastore = Datastore()
         virt.return_value.getCapabilities.return_value = LIBVIRT_CAPABILITIES_XML
         virt.return_value.getType.return_value = "LIBVIRT_TYPE"
@@ -135,7 +143,7 @@ class TestLibvirtd(TestBase):
 
     @patch('libvirt.openReadOnly')
     def test_mapping_has_no_hostname_when_unavailible(self, virt):
-        config = Config('test', 'libvirt', server='abc://server/test')
+        config = self.create_config('test', None, type='libvirt', server='abc://server/test')
         datastore = Datastore()
         virt.return_value.getCapabilities.return_value = LIBVIRT_CAPABILITIES_NO_HOSTNAME_XML
         virt.return_value.getType.return_value = "LIBVIRT_TYPE"

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -37,8 +37,8 @@ xvirt = type("", (), {'CONFIG_TYPE': 'xxx'})()
 
 class TestManager(TestBase):
     """ Test of all available subscription managers. """
-    guest1 = Guest('9c927368-e888-43b4-9cdb-91b10431b258', xvirt, Guest.STATE_RUNNING)
-    guest2 = Guest('d5ffceb5-f79d-41be-a4c1-204f836e144a', xvirt, Guest.STATE_SHUTOFF)
+    guest1 = Guest('9c927368-e888-43b4-9cdb-91b10431b258', xvirt.CONFIG_TYPE, Guest.STATE_RUNNING)
+    guest2 = Guest('d5ffceb5-f79d-41be-a4c1-204f836e144a', xvirt.CONFIG_TYPE, Guest.STATE_SHUTOFF)
     guestInfo = [guest1]
     hypervisor_id = "HYPERVISOR_ID"
 

--- a/tests/test_rhevm.py
+++ b/tests/test_rhevm.py
@@ -167,7 +167,7 @@ class TestRhevM(TestBase):
             guestIds=[
                 Guest(
                     expected_guestId,
-                    self.rhevm,
+                    self.rhevm.CONFIG_TYPE,
                     expected_guest_state,
                 )
             ],
@@ -211,7 +211,7 @@ class TestRhevM(TestBase):
             guestIds=[
                 Guest(
                     expected_guestId,
-                    self.rhevm,
+                    self.rhevm.CONFIG_TYPE,
                     expected_guest_state,
                 )
             ],

--- a/tests/test_satellite.py
+++ b/tests/test_satellite.py
@@ -147,13 +147,13 @@ class TestSatellite(TestBase):
     mapping = {
         'hypervisors': [
             Hypervisor('host-1', [
-                Guest('guest1-1', xvirt, Guest.STATE_RUNNING),
-                Guest('guest1-2', xvirt, Guest.STATE_SHUTOFF)
+                Guest('guest1-1', xvirt.CONFIG_TYPE, Guest.STATE_RUNNING),
+                Guest('guest1-2', xvirt.CONFIG_TYPE, Guest.STATE_SHUTOFF)
             ]),
             Hypervisor('host-2', [
-                Guest('guest2-1', xvirt, Guest.STATE_RUNNING),
-                Guest('guest2-2', xvirt, Guest.STATE_SHUTOFF),
-                Guest('guest2-3', xvirt, Guest.STATE_RUNNING)
+                Guest('guest2-1', xvirt.CONFIG_TYPE, Guest.STATE_RUNNING),
+                Guest('guest2-2', xvirt.CONFIG_TYPE, Guest.STATE_SHUTOFF),
+                Guest('guest2-3', xvirt.CONFIG_TYPE, Guest.STATE_RUNNING)
             ])
         ]
     }

--- a/tests/test_subscriptionmanager.py
+++ b/tests/test_subscriptionmanager.py
@@ -19,9 +19,9 @@ xvirt = type("", (), {'CONFIG_TYPE': 'xxx'})()
 
 class TestSubscriptionManager(TestBase):
     guestList = [
-        Guest('222', xvirt, Guest.STATE_RUNNING),
-        Guest('111', xvirt, Guest.STATE_RUNNING),
-        Guest('333', xvirt, Guest.STATE_RUNNING),
+        Guest('222', xvirt.CONFIG_TYPE, Guest.STATE_RUNNING),
+        Guest('111', xvirt.CONFIG_TYPE, Guest.STATE_RUNNING),
+        Guest('333', xvirt.CONFIG_TYPE, Guest.STATE_RUNNING),
     ]
     mapping = {
         'hypervisors': [Hypervisor('123', guestList, name='TEST_HYPERVISOR')]

--- a/tests/test_virt.py
+++ b/tests/test_virt.py
@@ -80,10 +80,10 @@ env=env
         config = config_manager.configs[0][1]
 
         included_hypervisor = Hypervisor('12345', guestIds=[
-            Guest('guest-2', xvirt, Guest.STATE_RUNNING),
+            Guest('guest-2', xvirt.CONFIG_TYPE, Guest.STATE_RUNNING),
         ])
         excluded_hypervisor = Hypervisor('00000', guestIds=[
-            Guest('guest-1', xvirt, Guest.STATE_RUNNING),
+            Guest('guest-1', xvirt.CONFIG_TYPE, Guest.STATE_RUNNING),
         ])
 
         assoc = {
@@ -216,8 +216,8 @@ class TestDestinationThread(TestBase):
         virt2 = Mock()
         virt2.CONFIG_TYPE = 'esx'
 
-        guest1 = Guest('GUUID1', virt1, Guest.STATE_RUNNING)
-        guest2 = Guest('GUUID2', virt2, Guest.STATE_RUNNING)
+        guest1 = Guest('GUUID1', virt1.CONFIG_TYPE, Guest.STATE_RUNNING)
+        guest2 = Guest('GUUID2', virt2.CONFIG_TYPE, Guest.STATE_RUNNING)
         assoc1 = {'hypervisors': [Hypervisor('hypervisor_id_1', [guest1])]}
         assoc2 = {'hypervisors': [Hypervisor('hypervisor_id_2', [guest2])]}
         report1 = HostGuestAssociationReport(config1, assoc1)
@@ -264,8 +264,8 @@ class TestDestinationThread(TestBase):
         virt2 = Mock()
         virt2.CONFIG_TYPE = 'esx'
 
-        guest1 = Guest('GUUID1', virt1, Guest.STATE_RUNNING)
-        guest2 = Guest('GUUID2', virt2, Guest.STATE_RUNNING)
+        guest1 = Guest('GUUID1', virt1.CONFIG_TYPE, Guest.STATE_RUNNING)
+        guest2 = Guest('GUUID2', virt2.CONFIG_TYPE, Guest.STATE_RUNNING)
         assoc1 = {'hypervisors': [Hypervisor('hypervisor_id_1', [guest1])]}
         assoc2 = {'hypervisors': [Hypervisor('hypervisor_id_2', [guest2])]}
         report1 = HostGuestAssociationReport(config1, assoc1)
@@ -338,8 +338,8 @@ class TestDestinationThread(TestBase):
         virt2 = Mock()
         virt2.CONFIG_TYPE = 'esx'
 
-        guest1 = Guest('GUUID1', virt1, Guest.STATE_RUNNING)
-        guest2 = Guest('GUUID2', virt2, Guest.STATE_RUNNING)
+        guest1 = Guest('GUUID1', virt1.CONFIG_TYPE, Guest.STATE_RUNNING)
+        guest2 = Guest('GUUID2', virt2.CONFIG_TYPE, Guest.STATE_RUNNING)
         assoc1 = {'hypervisors': [Hypervisor('hypervisor_id_1', [guest1])]}
         assoc2 = {'hypervisors': [Hypervisor('hypervisor_id_2', [guest2])]}
         report1 = HostGuestAssociationReport(config1, assoc1)
@@ -398,7 +398,7 @@ class TestDestinationThread(TestBase):
         virt1 = Mock()
         virt1.CONFIG_TYPE = 'esx'
 
-        guest1 = Guest('GUUID1', virt1, Guest.STATE_RUNNING)
+        guest1 = Guest('GUUID1', virt1.CONFIG_TYPE, Guest.STATE_RUNNING)
         report1 = DomainListReport(config1, [guest1],
                                    hypervisor_id='hypervisor_id_1')
 
@@ -434,7 +434,7 @@ class TestDestinationThread(TestBase):
         virt1 = Mock()
         virt1.CONFIG_TYPE = 'esx'
 
-        guest1 = Guest('GUUID1', virt1, Guest.STATE_RUNNING)
+        guest1 = Guest('GUUID1', virt1.CONFIG_TYPE, Guest.STATE_RUNNING)
         report1 = DomainListReport(config1, [guest1],
                                    hypervisor_id='hypervisor_id_1')
 
@@ -480,7 +480,7 @@ class TestDestinationThread(TestBase):
         config = Mock()
         manager = Mock()
 
-        guest1 = Guest('GUUID1', virt1, Guest.STATE_RUNNING)
+        guest1 = Guest('GUUID1', virt1.CONFIG_TYPE, Guest.STATE_RUNNING)
         report1 = DomainListReport(config1, [guest1],
                                    hypervisor_id='hypervisor_id_1')
         report2 = DomainListReport(config1, [guest1],

--- a/tests/test_xen.py
+++ b/tests/test_xen.py
@@ -119,7 +119,7 @@ class TestXen(TestBase):
             guestIds=[
                 Guest(
                     expected_guestId,
-                    self.xen,
+                    self.xen.CONFIG_TYPE,
                     expected_guest_state,
                 )
             ],
@@ -175,7 +175,7 @@ class TestXen(TestBase):
                 guestIds=[
                     Guest(
                         expected_guestId,
-                        self.xen,
+                        self.xen.CONFIG_TYPE,
                         expected_guest_state,
                     )
                 ],

--- a/virtwho/config.py
+++ b/virtwho/config.py
@@ -28,6 +28,12 @@ import hashlib
 import json
 import util
 
+try:
+    from collections import OrderedDict
+except ImportError:
+    # Python 2.6 doesn't have OrderedDict, we need to have our own
+    from util import OrderedDict
+
 # Module-level logger
 logger = log.getLogger('config', queue=False)
 
@@ -760,7 +766,6 @@ class ConfigSection(collections.MutableMapping):
     # The string representation of all default properties and values
     # Real values should be added in child classes
     DEFAULTS = ()
-    REQUIRED = ()
 
     __marker = object()
 
@@ -782,8 +787,10 @@ class ConfigSection(collections.MutableMapping):
         # Validation messages from last run
         self.validation_messages = []
 
-        self.validation_methods = {}
+        self.validation_methods = OrderedDict()
         self._destinations = {}
+        self._required_keys = set()
+        self._missing_required_keys = set()
 
         # Add section defaults
         for key, value in self.defaults.items():
@@ -803,7 +810,8 @@ class ConfigSection(collections.MutableMapping):
     def _update_state(self):
         if len(self._unvalidated_keys) > 0:
             self.state = ValidationState.NEEDS_VALIDATION
-        elif len(self._invalid_keys) > 0 or len(self._values) == 0:
+        elif len(self._invalid_keys) > 0 or len(self._values) == 0 or len(
+                self._missing_required_keys) > 0:
             self.state = ValidationState.INVALID
         else:
             self.state = ValidationState.VALID
@@ -848,8 +856,8 @@ class ConfigSection(collections.MutableMapping):
         """
         Steps necessary to do before evaluation 
         """
-        # FIXME: add some comments with some explanation
-        if 'virttype' in self._values:
+        # Used to allow virttype to be provided for type (if type was not given)
+        if 'virttype' in self._values and 'type' not in self._values:
             self._values['type'] = self._values['virttype']
 
         if len(self._unvalidated_keys) == 0:
@@ -865,15 +873,21 @@ class ConfigSection(collections.MutableMapping):
                         )
                     )
 
+    def check_required_keys(self):
+        for required_key in self._required_keys:
+            if required_key not in self and not self.has_default(required_key):
+                msg = ('error', 'Required option: "%s" is missing in: "%s"' % (required_key,
+                                                                               self.name))
+                self.validation_messages.append(msg)
+                self._missing_required_keys.add(required_key)
+
     def _post_validate(self):
         """
         Steps necessary to do after evaluation
         """
-        for required_key in self.REQUIRED:
-            if required_key not in self:
-                msg = ('error', 'Required option: "%s" is missing in: %s' % (required_key, self.name))
-                self.validation_messages.append(msg)
+        self.check_required_keys()
         self.reset_to_defaults()
+        self.apply_destinations()
         # Finally calls _update_state
         self._update_state()
 
@@ -883,26 +897,35 @@ class ConfigSection(collections.MutableMapping):
             return
         validation_messages = []
 
+        # remove unknown keys
+        unknown_keys = self._unvalidated_keys.difference(self.validation_methods.keys())
+        self._unvalidated_keys.difference_update(unknown_keys)
         # Validate those keys that need to be validated
-        for key in set(self._unvalidated_keys):
-            errors = None
-            try:
-                validation_method = self.validation_methods[key]
-                errors = validation_method(key)
-            except KeyError:
-                # We must not know of this parameter for the VirtConfigSection
-                validation_messages.append(
-                    ('warning', 'Ignoring unknown configuration option "%s"' % key)
-                )
-                del self._values[key]
-
-            if errors is not None:
-                if type(errors) is list:
-                    validation_messages.extend(errors)
+        for key, validation_method in self.validation_methods.iteritems():
+            if key not in self._unvalidated_keys:
+                continue
+            messages = validation_method(key)
+            key_invalid = False
+            if messages is not None:
+                if type(messages) is list:
+                    if any(message[0] == 'error' for message in messages):
+                        key_invalid = True
+                    validation_messages.extend(messages)
                 else:
-                    validation_messages.append(errors)
-                self._invalid_keys.add(key)
+                    if messages[0] == 'error':
+                        key_invalid = True
+                    validation_messages.append(messages)
+                # Only add if at least one result contains an 'error' level message
+                if key_invalid:
+                    self._invalid_keys.add(key)
             self._unvalidated_keys.remove(key)
+
+        for key in unknown_keys:
+            validation_messages.append(
+                    ('warning', 'Ignoring unknown configuration option "%s"' % key)
+            )
+            if key in self._values:
+                del self._values[key]
 
         self._update_state()
         self.validation_messages.extend(validation_messages)
@@ -922,10 +945,23 @@ class ConfigSection(collections.MutableMapping):
         When option is not set correctly or it was not set at all, then
         this methods tries to set such options to default values.
         """
-        for key in self._invalid_keys:
-            if self.has_default(key):
+        for key in self._invalid_keys.union(self.defaults.keys()):
+            if self.has_default(key) and key not in self._values:
                 self._values[key] = self.defaults[key]
-        self._invalid_keys = set()
+                if key in self._required_keys:
+                    message = 'Required option: "%s" is missing in: "%s" using default "%s"' % (key, self.name,
+                                                                                                self.defaults[key])
+                else:
+                    message = 'Value for "%s" not set in: "%s", using default: "%s"' % (key, self.name, self.get(key))
+                self.validation_messages.append(('warning', message))
+
+    def apply_destinations(self):
+        # Rudimentary, should we be copying values around or just referencing them
+        for key in self._destinations:
+            if key in self._values and self._destinations[key] not in self._values and key \
+                    not in self._invalid_keys:
+                self._values[self._destinations[key]] = self._values[key]
+                del self._values[key]
 
     def is_default(self, key):
         return key in self.defaults and (key not in self._values or self._values[key] == self.defaults[key])
@@ -1071,14 +1107,17 @@ class ConfigSection(collections.MutableMapping):
             self._values[list_key] = []  # Reset to empty list
         return result
 
-    def add_key(self, key, validation_method=None, default=None, destination=None):
-        if default is not None:
+    def add_key(self, key, validation_method=None, default=__marker, destination=None,
+                required=False):
+        if default is not self.__marker:
             self.defaults[key] = default
         if not validation_method:
             raise AttributeError('validation_method must be provided for {}'.format(key))
         self.validation_methods[key] = validation_method
         if destination:
             self._destinations[key] = destination
+        if required:
+            self._required_keys.add(key)
 
 
 class VirtConfigSection(ConfigSection):
@@ -1120,7 +1159,8 @@ class VirtConfigSection(ConfigSection):
         self.add_key('filter_hosts', validation_method=self._validate_filter)
         self.add_key('filter_host_parents', validation_method=self._validate_filter)
         self.add_key('exclude_hosts', validation_method=self._validate_filter)
-        self.add_key('exclude_host_parents', validation_method=self._validate_filter, default=None)
+        self.add_key('exclude_host_parents', validation_method=self._validate_filter,
+                     default=None)
         self.add_key('rhsm_proxy_hostname', validation_method=self._validate_non_empty_string)
         self.add_key('rhsm_proxy_port', validation_method=self._validate_non_empty_string)
         self.add_key('rhsm_hostname', validation_method=self._validate_non_empty_string)
@@ -1445,34 +1485,39 @@ class EffectiveConfig(collections.MutableMapping):
 
 
 def _check_effective_config_validity(effective_config):
-    validation_errors = []
-    effective_config.validate()
+    validation_errors = effective_config.validate()
+    valid_virt_sections = {}
+    invalid_virt_sections = {}
+    for name, section in effective_config.virt_sections():
+        if section.is_valid():
+            valid_virt_sections[name] = section
+        else:
+            invalid_virt_sections[name] = section
+    has_non_default_env_cli = False
 
-    valid_virt_sections = [(name, section) for (name, section) in effective_config.virt_sections()
-                           if section.is_valid()]
-
-    if not valid_virt_sections:
-        has_non_default_env_cli = False
-        validation_errors.append(('warning', 'No valid configurations found'))
-        # Check if ENV_CLI is default, if not fail
-        for name, section in effective_config.items():
-            if name == VW_GLOBAL:
-                # Always keep the global section
-                continue
-            if name == VW_ENV_CLI_SECTION_NAME:
+    # Drop invalid configurations first
+    if len(invalid_virt_sections.keys()) > 0:
+        for name, section in invalid_virt_sections.items():
+            if name == VW_ENV_CLI_SECTION_NAME and not section.is_section_default():
                 has_non_default_env_cli = True
             validation_errors.append(('warning', 'Dropping invalid configuration "%s"' % name))
             del effective_config[name]
+
+        # If there are no valid virt sections
+        if not valid_virt_sections:
+            validation_errors.append(('warning', 'No valid configurations found'))
+
+    # In order to keep compatibility with older releases of virt-who,
+    # fallback to using libvirt as default virt backend
+    # only if we did not have a non_default env/cmdline config
+    if not has_non_default_env_cli and len(effective_config.virt_sections()) == 0 and len(
+            invalid_virt_sections) == 0:
+        effective_config[VW_ENV_CLI_SECTION_NAME] = ConfigSection.from_dict(
+                DEFAULTS[VW_ENV_CLI_SECTION_NAME],
+                VW_ENV_CLI_SECTION_NAME,
+                effective_config)
         validation_errors.append(('warning',
-                                  'Using default "%s" configuration' % name))
-        # In order to keep compatibility with older releases of virt-who,
-        # fallback to using libvirt as default virt backend
-        # only if we did not have a non_default env/cmdline config
-        if not has_non_default_env_cli:
-            effective_config[VW_ENV_CLI_SECTION_NAME] = ConfigSection.from_dict(
-                    DEFAULTS[VW_ENV_CLI_SECTION_NAME],
-                    VW_ENV_CLI_SECTION_NAME,
-                    effective_config)
+                                  'Using default "%s" configuration' % VW_ENV_CLI_SECTION_NAME))
 
     effective_config.validate()
     return effective_config, validation_errors
@@ -1564,7 +1609,7 @@ def init_config(env_options, cli_options, config_dir=VW_CONF_DIR):
     # Log pending errors
     for err in validation_errors:
         method = getattr(logger, err[0])
-        if method is not None:
+        if method is not None and err[0] == 'error':
             method(err[1])
 
     return effective_config

--- a/virtwho/datastore.py
+++ b/virtwho/datastore.py
@@ -58,7 +58,7 @@ class Datastore(object):
         """
         with self._datastore_lock:
             try:
-                item = self._datastore[key]
+                item = copy.deepcopy(self._datastore[key])
                 return item
             except KeyError:
                 if default:

--- a/virtwho/parser.py
+++ b/virtwho/parser.py
@@ -493,7 +493,7 @@ def parse_options():
     # Log pending errors
     for err in errors:
         method = getattr(logger, err[0])
-        if method is not None:
+        if method is not None and err[0] == 'error':
             method(err[1])
 
     return logger, effective_config

--- a/virtwho/virt/esx/esx.py
+++ b/virtwho/virt/esx/esx.py
@@ -293,7 +293,7 @@ class Esx(virt.Virt):
                             state = virt.Guest.STATE_SHUTOFF
                     except KeyError:
                         self.logger.debug("Guest '%s' doesn't have 'runtime.powerState' property", vm_id.value)
-                    guests.append(virt.Guest(vm['config.uuid'], self, state))
+                    guests.append(virt.Guest(vm['config.uuid'], self.CONFIG_TYPE, state))
             try:
                 name = host['config.network.dnsConfig.hostName']
                 domain_name = host['config.network.dnsConfig.domainName']
@@ -498,10 +498,12 @@ class EsxConfigSection(VirtConfigSection):
 
     def __init__(self, *args, **kwargs):
         super(EsxConfigSection, self).__init__(*args, **kwargs)
-
+        self.add_key('env', validation_method=self._validate_env, required=True)
+        self.add_key('owner', validation_method=self._validate_owner, required=True)
+        self.add_key('is_hypervisor', validation_method=self._validate_str_to_bool, default=True)
         self.add_key('simplified_vim', validation_method=self._validate_str_to_bool, default=True)
-        self.add_key('filter_host_parents', validation_method=self._validate_filter)
-        self.add_key('exclude_host_parents', validation_method=self._validate_filter)
+        self.add_key('filter_host_parents', validation_method=self._validate_filter, default=None)
+        self.add_key('exclude_host_parents', validation_method=self._validate_filter, default=None)
 
     def _validate_server(self, key):
         error = super(EsxConfigSection, self)._validate_server(key)

--- a/virtwho/virt/fakevirt/fakevirt.py
+++ b/virtwho/virt/fakevirt/fakevirt.py
@@ -1,8 +1,70 @@
+# -*- coding: utf-8 -*-
+
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
 
 import json
 
+from virtwho.config import VirtConfigSection, accessible_file, str_to_bool
 from virtwho.virt import Virt, VirtError, Guest, Hypervisor
 from virtwho.util import decode
+
+
+class FakeVirtConfigSection(VirtConfigSection):
+    """
+    This class is used for validation of fake virtualization backend
+    section(s). It tries to validate options and combination of options that
+    are specific for this virtualization backend. In specific, it attempts to read
+    the given file and produces error messages if it is not usable.
+    """
+    VIRT_TYPE = 'fake'
+
+    def __init__(self, *args, **kwargs):
+        super(FakeVirtConfigSection, self).__init__(*args, **kwargs)
+        self.add_key('is_hypervisor', validation_method=self._validate_str_to_bool, default=True,
+                     required=True)
+        self.add_key('file', validation_method=self._validate_fake_virt_file, required=True)
+
+    def _validate_fake_virt_file(self, key):
+        file_path = self.get(key)
+        # Ensure the value we've got is a file we can access
+        try:
+            accessible_file(file_path)
+        except ValueError as e:
+            message = "Error validating key '%s': '%s'" % (key, str(e))
+            return 'error', message
+        # We do not know if the is_hypervisor key will have been parsed yet
+        # TODO Allow for specification of which key requires which parsed values
+        try:
+            is_hypervisor = self.get('is_hypervisor')
+            if type(is_hypervisor) is str:
+                is_hypervisor = str_to_bool(is_hypervisor)
+        except ValueError as e:
+            message = "Error validating key '%s': '%s'" % (key, str(e))
+            return 'error', message
+        try:
+            if is_hypervisor is True:
+                # Try to read and parse the file as if it were a host guest mapping
+                FakeVirt.read_host_guest_mapping_from_file(file_path)
+            elif is_hypervisor is False:
+                # Try to read and parse the file as if it were a domain list
+                FakeVirt.list_domains_from_file(file_path)
+        except VirtError as e:
+            message = "Error validating key '%s': '%s'" % (key, str(e))
+            return 'error', message
 
 
 class FakeVirt(Virt):
@@ -17,49 +79,62 @@ class FakeVirt(Virt):
         self.logger = logger
         self.config = config
 
-    def _read_data(self):
+    @staticmethod
+    def _read_data(file_path):
         # TODO: do some checking of the file content
         try:
-            with open(self.config.file, 'r') as f:
+            with open(file_path, 'r') as f:
                 return json.load(f, object_hook=decode)
         except (IOError, ValueError) as e:
-            raise VirtError("Can't read fake '%s' virt data: %s" % (self.config.file, str(e)))
+            raise VirtError("Can't read fake '%s' virt data: %s" % (file_path, str(e)))
 
     def isHypervisor(self):
-        if self.config.is_hypervisor is None:
+        if self.config["is_hypervisor"] is None:
             return True
-        return self.config.is_hypervisor
+        return self.config["is_hypervisor"]
 
-    def _process_guest(self, guest):
+    @classmethod
+    def process_guest(cls, guest):
         attributes = guest.get('attributes', {})
-        self.CONFIG_TYPE = attributes.get('virtWhoType', 'fake')
-        return Guest(guest['guestId'], self, guest['state'])
+        virt_type = attributes.get('virtWhoType', 'fake')
+        return Guest(guest['guestId'], virt_type, guest['state'])
 
-    def _process_hypervisor(self, hypervisor):
+    @classmethod
+    def process_hypervisor(cls, hypervisor):
         guests = []
         for guest in hypervisor['guests']:
-            guests.append(self._process_guest(guest))
+            guests.append(cls.process_guest(guest))
         return Hypervisor(hypervisor['uuid'],
                           guests,
                           hypervisor.get('name'),
                           hypervisor.get('facts'))
 
-    def getHostGuestMapping(self):
+    @classmethod
+    def read_host_guest_mapping_from_file(cls, file_path):
+        # Used to read the host-guest mapping from a file. Raises VirtError if
+        # we are unable to parse the file
         assoc = {'hypervisors': []}
         try:
-            for hypervisor in self._read_data()['hypervisors']:
-                assoc['hypervisors'].append(self._process_hypervisor(hypervisor))
+            for hypervisor in cls._read_data(file_path)['hypervisors']:
+                assoc['hypervisors'].append(cls.process_hypervisor(hypervisor))
         except KeyError as e:
-            raise VirtError("Fake virt file '%s' is not properly formed: %s" % (self.config.file, str(e)))
+            raise VirtError("Fake virt file '%s' is not properly formed: %s" % (file_path, str(e)))
         return assoc
 
-    def listDomains(self):
-        hypervisor = self._read_data()['hypervisors'][0]
+    def getHostGuestMapping(self):
+        return self.read_host_guest_mapping_from_file(self.config['file'])
+
+    @classmethod
+    def list_domains_from_file(cls, file_path):
+        hypervisor = cls._read_data(file_path)['hypervisors'][0]
         if 'uuid' in hypervisor:
             raise VirtError("Fake virt file '%s' is not properly formed: "
                             "uuid key shouldn't be present, try to check is_hypervisor value" %
-                            self.config.file)
+                            file_path)
         guests = []
         for guest in hypervisor['guests']:
-            guests.append(self._process_guest(guest))
+            guests.append(cls.process_guest(guest))
         return guests
+
+    def listDomains(self):
+        return self.list_domains_from_file(self.config['file'])

--- a/virtwho/virt/hyperv/hyperv.py
+++ b/virtwho/virt/hyperv/hyperv.py
@@ -590,7 +590,7 @@ class HyperV(virt.Virt):
                 self.logger.warning("Unknown state for guest %s", elementName)
                 state = virt.Guest.STATE_UNKNOWN
 
-            guests.append(virt.Guest(HyperV.decodeWinUUID(uuid), self, state))
+            guests.append(virt.Guest(HyperV.decodeWinUUID(uuid), self.CONFIG_TYPE, state))
         # Get the hostname
         hostname = None
         socket_count = None

--- a/virtwho/virt/libvirtd/libvirtd.py
+++ b/virtwho/virt/libvirtd/libvirtd.py
@@ -66,12 +66,18 @@ class LibvirtdConfigSection(VirtConfigSection):
 
             if splitted_url.scheme:
                 scheme = splitted_url.scheme
-            else:
+            elif 'password' not in self._values:
                 result.append((
                     'info',
                     "Protocol is not specified in libvirt url, using qemu+ssh://"
                 ))
                 scheme = 'qemu+ssh'
+            else:
+                result.append((
+                    'info',
+                    "Protocol is not specified in libvirt url, using qemu://"
+                ))
+                scheme = 'qemu'
 
             if 'username' in self._values:
                 username = self._values['username']
@@ -179,7 +185,7 @@ class LibvirtdConfigSection(VirtConfigSection):
 
 
 class LibvirtdGuest(Guest):
-    def __init__(self, libvirtd, domain):
+    def __init__(self, domain):
         try:
             state = domain.state(0)[0]
         except AttributeError:
@@ -189,7 +195,7 @@ class LibvirtdGuest(Guest):
 
         super(LibvirtdGuest, self).__init__(
             uuid=domain.UUIDString(),
-            virt=libvirtd,
+            virt_type=Libvirtd.CONFIG_TYPE,
             state=state)
 
 
@@ -271,7 +277,7 @@ class Libvirtd(Virt):
         self.eventLoopThread.start()
 
     def _connect(self):
-        url = self.config.get('server', None)
+        url = self.config.get('server', "")
         self.logger.info("Using libvirt url: %s", url if url else '""')
         try:
             if self.config.get('password', None):
@@ -372,7 +378,7 @@ class Libvirtd(Virt):
                 if domain.UUIDString() == "00000000-0000-0000-0000-000000000000":
                     # Don't send Domain-0 on xen (zeroed uuid)
                     continue
-                domains.append(LibvirtdGuest(self, domain))
+                domains.append(LibvirtdGuest(domain))
 
             # Non active domains
             for domainName in self.virt.listDefinedDomains():
@@ -382,7 +388,7 @@ class Libvirtd(Virt):
                     self.logger.debug("Lookup for domain by name '%s' failed, probably it was just destroyed, ignoring" % domainName)
                     continue
 
-                domains.append(LibvirtdGuest(self, domain))
+                domains.append(LibvirtdGuest(domain))
         except libvirt.libvirtError as e:
             self.virt.close()
             raise VirtError(str(e))

--- a/virtwho/virt/virt.py
+++ b/virtwho/virt/virt.py
@@ -61,7 +61,7 @@ class Guest(object):
 
     def __init__(self,
                  uuid,
-                 virt,
+                 virt_type,
                  state,
                  hypervisorType=None):
         """
@@ -75,7 +75,7 @@ class Guest(object):
         `state` is a number that represents the state of the guest (stopped, running, ...)
         """
         self.uuid = uuid
-        self.virtWhoType = virt.CONFIG_TYPE
+        self.virtWhoType = virt_type
         self.state = state
 
     def __repr__(self):

--- a/virtwho/virt/xen/xen.py
+++ b/virtwho/virt/xen/xen.py
@@ -108,7 +108,7 @@ class Xen(virt.Virt):
                 else:
                     state = virt.Guest.STATE_UNKNOWN
 
-                guests.append(virt.Guest(uuid=uuid, virt=self, state=state))
+                guests.append(virt.Guest(uuid=uuid, virt_type=self.CONFIG_TYPE, state=state))
 
             facts = {}
             sockets = record.get('cpu_info', {}).get('socket_count')


### PR DESCRIPTION
This adds a VirtConfigSection subclass for use with the fake backend.

There has also been an addition to the the ConfigSection class's add_key method.
Now you can specify which keys are required by adding "required=True" to any calls you make to add_key.

When considering the state of a config object if there are any required keys that are missing that config is considered invalid.

Please note: there are still numerous failing tests, but there should not be any more than config_refactor branch. And all the FakeVirt specific ones work.

(Additional PR fixing many (if not all) of the tests broken in config_refactor branch coming soon)


This branch has become a bit of a monster (might have gotten carried away trying to fix tests etc).

Notable changes:
- Only messages returned from _validate_* methods that have 'error' as the first value will be displayed.
- ConfigSection._validate considers only those keys whose associated validation_method returns at least one message with the 'error' level to be invalid, all other messages are stored.
- Added unit tests for the add_key method (including a number of scenarios)
- Numerous changes for unit test fixes (still a number broken but down to around 40 instead of 110+)
