### PR TITLE
1502821: Remove undocumented, broken env var "VIRTWHO_DISABLE_ASYNC"

### DIFF
--- a/virtwho/manager/subscriptionmanager/subscriptionmanager.py
+++ b/virtwho/manager/subscriptionmanager/subscriptionmanager.py
@@ -284,10 +284,6 @@ class SubscriptionManager(Manager):
         else:
             self.logger.debug("Server does not have 'hypervisors_async' capability")
 
-        if is_async and os.environ.get('VIRTWHO_DISABLE_ASYNC', '').lower() in ['1', 'yes', 'true']:
-            self.logger.info("Async reports are supported but explicitly disabled")
-            is_async = False
-
         return is_async
 
     def _hypervisor_mapping(self, report, is_async, connection=None):

--- a/virtwho/parser.py
+++ b/virtwho/parser.py
@@ -465,6 +465,10 @@ def parse_options():
     VIRT_TYPE_OPTIONS = ['owner', 'env', 'server', 'username', 'password']
     SAT_OPTION_MAP = {'sat_server':'satellite-server', 'sat_username':'satellite-username', 'sat_password':'satellite-password'}
 
+    # Deprecated Environement variables
+    DEPRECATED_ENV_VARS = set(['VIRTWHO_DISABLE_ASYNC'])
+    present_deprecated_env_vars = list(set(os.environ.keys()).intersection(DEPRECATED_ENV_VARS))
+
     # Read command line arguments first
     cli_options, defaults = parse_cli_arguments()
 
@@ -476,6 +480,7 @@ def parse_options():
 
     # Read configuration env. variables
     errors = read_config_env_variables(options)
+    errors.append(('warning', 'The following present environment variables are deprecated and will be ignored: {0}'.format(present_deprecated_env_vars)))
 
     # It is possible to initialize logger now
     log.init(options)


### PR DESCRIPTION
The is an env var that is undocumented and broken that half disables async hypervisor checkins.

This PR fixes it's broken functionality by removing it entirely (after discussion with QE).