### PR TITLE
1503700: Updates to the job polling frequency

### DIFF
--- a/tests/test_virt.py
+++ b/tests/test_virt.py
@@ -8,6 +8,7 @@ from base import TestBase
 from mock import Mock, patch, call
 from threading import Event
 
+from virtwho import MinimumJobPollInterval
 from virtwho.config import ConfigManager, Config
 from virtwho.manager import ManagerThrottleError, ManagerFatalError
 from virtwho.virt import HostGuestAssociationReport, Hypervisor, Guest, \
@@ -279,7 +280,7 @@ class TestDestinationThread(TestBase):
             local_variables = {'count': 0}
 
             def mock_check_report_state(report):
-                if local_variables['count'] > 0:
+                if local_variables['count'] > 1:
                     report.state = AbstractVirtReport.STATE_FINISHED
                 else:
                     report.state = AbstractVirtReport.STATE_CREATED
@@ -290,7 +291,6 @@ class TestDestinationThread(TestBase):
         manager.check_report_state = Mock(side_effect=check_report_mock)
         logger = Mock()
         config = Mock()
-        config.polling_interval = 10
         terminate_event = Mock()
         interval = 10  # Arbitrary for this test
         options = Mock()
@@ -307,15 +307,13 @@ class TestDestinationThread(TestBase):
         destination_thread.wait = Mock()
         destination_thread.is_terminated = Mock(return_value=False)
         destination_thread._send_data(data_to_send)
-        # We expect there two be two calls to wait with the value of the
-        # polling_interval attr because we'd like to wait one polling
-        # interval before making the first check. Because the mock
-        # check_report_state function will modify the report to be in the
-        # successful state after the first call, we expect to wait exactly
-        # twice, both of duration config.polling_interval
+        # There should be three waits, one after the job is submitted with duration of
+        # MinimumJobPollingInterval. The second and third with duration MinimumJobPollInterval * 2
+        # (and all subsequent calls as demonstrated by the third wait)
         destination_thread.wait.assert_has_calls([
-            call(wait_time=config.polling_interval),
-        ])
+            call(wait_time=MinimumJobPollInterval),
+            call(wait_time=MinimumJobPollInterval * 2),
+            call(wait_time=MinimumJobPollInterval * 2)])
 
     def test_send_data_poll_async_429(self):
         # This test's that when a 429 is detected during async polling
@@ -339,7 +337,6 @@ class TestDestinationThread(TestBase):
         data_to_send = {'source1': report1,
                         'source2': report2}
         config = Mock()
-        config.polling_interval = 10
         error_to_throw = ManagerThrottleError(retry_after=62)
 
         manager = Mock()
@@ -360,7 +357,8 @@ class TestDestinationThread(TestBase):
                 return report
             return mock_check_report_state
         states = [error_to_throw, AbstractVirtReport.STATE_FINISHED]
-        expected_wait_calls = [call(wait_time=error_to_throw.retry_after)]
+        expected_wait_calls = [call(wait_time=MinimumJobPollInterval),
+                               call(wait_time=error_to_throw.retry_after)]
 
         check_report_mock = check_report_state_closure(states)
         manager.check_report_state = Mock(side_effect=check_report_mock)

--- a/virtwho/__init__.py
+++ b/virtwho/__init__.py
@@ -2,3 +2,4 @@
 # Default interval for sending list of UUIDs
 DefaultInterval = 3600  # One per hour
 MinimumSendInterval = 60  # One minute
+MinimumJobPollInterval = 15

--- a/virtwho/manager/subscriptionmanager/subscriptionmanager.py
+++ b/virtwho/manager/subscriptionmanager/subscriptionmanager.py
@@ -320,6 +320,8 @@ class SubscriptionManager(Manager):
             result = self.connection.getJob(job_id)
         except BadStatusLine:
             raise ManagerError("Communication with subscription manager interrupted")
+        except rhsm_connection.RateLimitExceededException as e:
+            raise ManagerThrottleError(e.retry_after)
         except rhsm_connection.ConnectionException as e:
             if hasattr(e, 'code'):
                 raise ManagerError("Communication with subscription manager failed with code %d: %s" % (e.code, str(e)))


### PR DESCRIPTION
After this update destination threads will poll for job status in the following
way.

The first job status check is made 15 seconds after submitting the job.
All subsequent job status checks that do not indicate the job is finished, cancelled or failed
result in a wait time of 30 seconds.

If during any job check an HTTP code 429 is returned including a 'Retry-After' header with a
value parsable as an integer, that value is used as the number of seconds to wait before the
next job check.

As soon as any job check returns success no more polling is done for that job.
This does not change the behavior of oneshot (still exits on 429 or other exception).


A fun way to test this is to use mitmproxy to fake 429s with different headers coming back.

1) Here is a libvirt config I used for testing this a bit (put this in a .conf file in /etc/virt-who.d):
```ini
[LOCAL_LIBVIRT]
type=libvirt
server=qemu:///system
owner=admin
env=admin
rhsm_hostname=localhost
rhsm_port=8443
rhsm_username=admin
rhsm_password=admin
rhsm_prefix=/candlepin
rhsm_proxy_hostname=localhost
rhsm_proxy_port=12345
#filter_hosts=d5b15581-5440-11cb-930e-b5dfde6103bc
hypervisor_id=hostname
```

2) deploy CP locally with test data

3) start mitmproxy (if you don't have it you should be able to install using pip `pip install mitmproxy`
    `mitmproxy --insecure  --port 12345`

4) Configure mitmproxy's intercept filter:
    a) press 'i'
    b) enter the following (without quotes) as the filter expression: `~bs [jJ]ob ~m GET`

5) run virt-who from the checkout: `./virt-who -d`
6) watch mitmproxy as requests come in. It should highlight and intercept any job status calls.
7) Move down to the intercepted call using the arrow keys and press enter
8) Press tab to go to the response
9) Press 'e' and then 'o' to edit the response code, delete the value already there and replace with 429 and press enter
10) Press 'e' and then 'h' to edit the headers
11) Move down to the last header by using the arrow keys and press 'a' to add a new one
12) Add the header 'Retry-After', press tab, type your desired wait time and press enter
13) press 'q' a few times to get back to the main screen of mitmproxy, then press 'a' to allow the modified response to be delivered to virt-who
14) Profit!! (and by this I mean, watch for virt-who to wait to retry the polling for the number of seconds you specified as the Retry-After header in step 12)


(with any luck this will serve as a useful mini-tutorial for someone)