### PR TITLE
1509597: Fix issue with cli consistancy check for vdsm 

### DIFF
--- a/virtwho/parser.py
+++ b/virtwho/parser.py
@@ -42,6 +42,7 @@ SAT_VM_DISPATCHER = {
     'xen': {'owner': False, 'env': False, 'server': True, 'username': True},
     'rhevm': {'owner': False, 'env': False, 'server': True, 'username': True},
     'hyperv': {'owner': False, 'env': False, 'server': True, 'username': True},
+    'vdsm': {'owner': False, 'env': False, 'server': False, 'username': False},
 }
 
 SAM_VM_DISPATCHER = {
@@ -50,6 +51,7 @@ SAM_VM_DISPATCHER = {
     'xen': {'owner': True, 'env': True, 'server': True, 'username': True},
     'rhevm': {'owner': True, 'env': True, 'server': True, 'username': True},
     'hyperv': {'owner': True, 'env': True, 'server': True, 'username': True},
+    'vdsm': {'owner': False, 'env': False, 'server': False, 'username': False},
 }
 
 

--- a/virtwho/virt/virt.py
+++ b/virtwho/virt/virt.py
@@ -567,7 +567,8 @@ class DestinationThread(IntervalThread):
 
         # Reports of different types are handled differently
         for source_key, report in data_to_send.iteritems():
-            if getattr(self.config, 'owner', None) is None:
+            if getattr(self.config, 'owner', None) is None and \
+                    isinstance(report, HostGuestAssociationReport):
                 # If the owner on our config is not defined, set it to the first report that
                 # we've found. This should be ok because destination threads should not be run for
                 # more than one owner.


### PR DESCRIPTION
Fixes an issue checking the consistency of CLI arguments. A case was missing that would cause virt-who to fail to run with the '--vdsm' CLI option.

This PR is based off of #114 (as one of the issues reported in this bug was fixed by that PR).
Please do not merge until #114 is merged.

see the following for more [details][1]

[1]: https://bugzilla.redhat.com/show_bug.cgi?id=1509597