### PR TITLE
1510760: Ensure virt-who exits properly (w/ no good conf)

### DIFF
--- a/virtwho/main.py
+++ b/virtwho/main.py
@@ -33,7 +33,7 @@ except ImportError:
 from virtwho import log
 from virtwho.config import InvalidPasswordFormat, VW_GLOBAL
 from virtwho.daemon import daemon
-from virtwho.executor import Executor, ReloadRequest
+from virtwho.executor import Executor, ReloadRequest, ExitRequest
 from virtwho.parser import parse_options, OptionError
 from virtwho.password import InvalidKeyFile
 from virtwho.virt import DomainListReport, HostGuestAssociationReport
@@ -179,6 +179,8 @@ def main():
             except ReloadRequest:
                 logger.info("Reloading")
                 continue
+            except ExitRequest as e:
+                exit(e.code, status=e.message)
 
 
 def _main(executor):
@@ -232,7 +234,7 @@ def exit(code, status=None):
 
     If status is not None, use sd_notify to report the status to systemd
     """
-    if status is not None:
+    if status is not None and status != "":
         sd_notify("STATUS=%s" % status)
 
     if executor:

--- a/virtwho/virt/virt.py
+++ b/virtwho/virt/virt.py
@@ -409,7 +409,6 @@ class IntervalThread(Thread):
         except KeyboardInterrupt:
             self.logger.debug("Thread '%s' interrupted", self.config.name)
             self.cleanup()
-            sys.exit(1)
 
     def cleanup(self):
         '''
@@ -917,7 +916,7 @@ class Virt(IntervalThread):
 
     def _send_data(self, data_to_send):
         if self.is_terminated():
-            sys.exit(0)
+            return
         self.logger.info('Report for config "%s" gathered, placing in '
                           'datastore', data_to_send.config.name)
         self.dest.put(self.config.name, data_to_send)


### PR DESCRIPTION
Stops all use of sys.exit in the executor.
Now when the executor needs to exit, an ExitRequest is raised (with an appropriate exit code and message).

The exit function of virtwho.main ensures resources are destroyed as they need to be.
This function is called in response to an ExitRequest raised from the executor.