### PR TITLE
1509606: Remove duplicate output of validation messages

### DIFF
--- a/tests/test_config_section.py
+++ b/tests/test_config_section.py
@@ -92,7 +92,7 @@ class TestConfigSection(TestBase):
         expected_results = [
             (
                 'error',
-                'Required option: "must_have" is missing in: "my_section"'
+                'Required option: "must_have" not set.'
             )
         ]
         self.assertEqual(result, expected_results)
@@ -110,7 +110,7 @@ class TestConfigSection(TestBase):
             ),
             (
                 'error',
-                'Required option: "must_have" is missing in: "my_section"'
+                'Required option: "must_have" not set.'
             )
         ]
         self.assertEqual(result, expected_results)
@@ -142,8 +142,8 @@ class TestConfigSection(TestBase):
         self.my_config['my_bool'] = True
         result = self.my_config.validate()
         expected_result = [
-            ('warning', 'Value for "my_list" not set in: my_section, using default: []'),
-            ('warning', 'Value for "my_str" not set in: my_section, using default: bar'),
+            ('warning', 'Value for "my_list" not set, using default: []'),
+            ('warning', 'Value for "my_str" not set, using default: bar'),
         ]
         self.assertEqual(result, expected_result)
         self.assertEqual(self.my_config['my_str'], 'bar')

--- a/virtwho/parser.py
+++ b/virtwho/parser.py
@@ -497,6 +497,7 @@ def parse_options():
 
     logger = log.getLogger("init", queue=False)
 
+    used_deprecated_cli_options = []
     for option in DEPRECATED_OPTIONS:
         display_option = option
         if option in cli_options and not cli_options[option] == defaults[option]:
@@ -506,22 +507,12 @@ def parse_options():
                 display_option = '%s-%s' % (cli_options['virtType'], option)
             elif option in SAT_OPTION_MAP:
                 display_option = SAT_OPTION_MAP[option]
-            logger.warning("The option --%s is deprecated and will be removed in the next release. "
-                  "Please see 'man virt-who-config' for details on adding a configuration section." % display_option)
-
-
-
-    for option in DEPRECATED_OPTIONS:
-        display_option = option
-        if option in cli_options and not cli_options[option] == defaults[option]:
-            if option == 'virtType' or option == 'smType':
-                display_option = cli_options[option]
-            elif any(option in s for s in VIRT_TYPE_OPTIONS):
-                display_option = '%s-%s' % (cli_options['virtType'], option)
-            elif option in SAT_OPTION_MAP:
-                display_option = SAT_OPTION_MAP[option]
-            logger.warning("The option --%s is deprecated and will be removed in the next release. "
-                  "Please see 'man virt-who-config' for details on adding a configuration section." % display_option)
+            used_deprecated_cli_options.append(display_option)
+    deprecated_options_msg = "The following cli options: %s are deprecated and will be removed " \
+    "in the next release. Please see 'man virt-who-config' for details on adding a configuration "\
+    "section."
+    if used_deprecated_cli_options:
+        logger.warning(deprecated_options_msg % ', '.join('--' + item for item in used_deprecated_cli_options))
 
     # Log pending errors
     for err in errors:


### PR DESCRIPTION
- All output messages for config sections are prepended with the name of the section for which they apply.
- Logs only one message for all deprecated cli options.