### PR TITLE
1512778: ESX should require username, password, and server values

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -71,8 +71,11 @@ class ConfigSectionValidationTests(object):
     # Should be changed for each set of tests, to make sure the right class is utilized
     CONFIG_CLASS = VirtConfigSection
 
-    def create_config(self):
-        return self.CONFIG_CLASS("test", None)
+    # should be a list of the keys which are required
+    REQUIRED_KEYS = set()
+
+    # Those keys that should have a default
+    KEYS_WITH_DEFAULTS = set()
 
     def _modified_dict(self, values, excluding=None, including=None):
         """
@@ -113,7 +116,8 @@ class ConfigSectionValidationTests(object):
         """
         config = self.CONFIG_CLASS.from_dict(self.VALID_CONFIG, "test", None)
 
-        self.assertIsInstance(config, self.CONFIG_CLASS, 'Wrong type of config, was "type" set correctly in "VALID_CONFIG"')
+        self.assertIsInstance(config, self.CONFIG_CLASS, 'Wrong type of config, was "type" set'
+                                                         'correctly in "VALID_CONFIG"?')
 
         # Having been updated, the config section needs validation
         self.assertEqual(config.state, ValidationState.NEEDS_VALIDATION)
@@ -133,7 +137,7 @@ class ConfigSectionValidationTests(object):
         """
         config = self.CONFIG_CLASS("test", None)
         # A sorted list of keys that are required, but have no default
-        target_keys = sorted(list(config._required_keys - set(config.defaults.keys())))
+        target_keys = sorted(list(self.REQUIRED_KEYS - self.KEYS_WITH_DEFAULTS))
         config_values = self._modified_dict(self.VALID_CONFIG, excluding=target_keys)
         config.update(**config_values)
 
@@ -151,7 +155,7 @@ class ConfigSectionValidationTests(object):
         NOTE: This does not account for modifications of default values made during validation.
         """
         config = self.CONFIG_CLASS("test", None)
-        target_keys = sorted(list(config._required_keys & set(config.defaults.keys())))
+        target_keys = sorted(list(self.REQUIRED_KEYS & self.KEYS_WITH_DEFAULTS))
         config_values = self._modified_dict(self.VALID_CONFIG, excluding=target_keys)
         config.update(**config_values)
 

--- a/tests/base.py
+++ b/tests/base.py
@@ -1,7 +1,7 @@
 """
 Basic module for tests,
 
-Copyright (C) 2014 Radek Novacek <rnovacek@redhat.com>
+Copyright (C) 2017 Radek Novacek <rnovacek@redhat.com>
 
 This program is free software; you can redistribute it and/or
 modify it under the terms of the GNU General Public License
@@ -20,7 +20,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 import logging
 from mock import patch, MagicMock
-from virtwho.config import VirtConfigSection
+from virtwho.config import VirtConfigSection, ValidationState
 
 # hack to use unittest2 on python <= 2.6, unittest otherwise
 # based on python version
@@ -51,3 +51,114 @@ class TestBase(unittest.TestCase):
         # Returns the mock_config and the dictionary that underlies it (useful for modifying the
         # contents of the config, without messing up the expected call stack of the mock_config
         return mock_config, kwargs
+
+
+class ConfigSectionValidationTests(object):
+    """
+    This is a group of tests which are meant to test that a config section subclass ends up in the
+    correct state, after validation, given various inputs.
+
+    Can be used as a mixin to add these tests to any suite (that has valid values for the required
+    class attributes).
+
+    This is not a test case itself as we do not expect these tests to pass as written without a
+    specific backend CONFIG_CLASS.
+    """
+
+    # A dictionary of valid configuration values
+    VALID_CONFIG = {}
+
+    # Should be changed for each set of tests, to make sure the right class is utilized
+    CONFIG_CLASS = VirtConfigSection
+
+    def create_config(self):
+        return self.CONFIG_CLASS("test", None)
+
+    def _modified_dict(self, values, excluding=None, including=None):
+        """
+        Copies a dict removing values where necessary
+        Args:
+            values: a dict of values to take from
+            excluding: a list or set of items to exclude from the copied dict
+            including: a list or set of items to include from the copied dict (wins over exclude)
+
+        Returns: a copied and modified dict
+
+        """
+        if excluding is None:
+            excluding = set()
+        if isinstance(excluding, list):
+            excluding = set(excluding)
+
+        if including is None:
+            including = set()
+        if isinstance(including, list):
+            including = set(including)
+
+        excluding = excluding - including
+
+        out = {}
+        for key in values.keys():
+            if key in including or not including:
+                out[key] = values[key]
+            if key in out and (key in excluding or (including and key not in including)):
+                del out[key]
+        return out
+
+    def test_valid_config(self):
+        """
+        This is essentially a smoke test to ensure the following:
+        1) An instance of the correct class is created from the valid configuration info
+        2) That the configuration is in the proper state pre and post validation
+        """
+        config = self.CONFIG_CLASS.from_dict(self.VALID_CONFIG, "test", None)
+
+        self.assertIsInstance(config, self.CONFIG_CLASS, 'Wrong type of config, was "type" set correctly in "VALID_CONFIG"')
+
+        # Having been updated, the config section needs validation
+        self.assertEqual(config.state, ValidationState.NEEDS_VALIDATION)
+
+        messages = config.validate()
+
+        # The config state should be valid, post validation with valid config information
+        self.assertEqual(config.state, ValidationState.VALID)
+
+        # There should be no error messages if this config section is valid
+        self.assertFalse(any(message[0] == 'error' for message in messages))
+
+    def test_missing_required_no_default(self):
+        """
+        This tests that when a required key, which has no default, is missing, the config section
+        becomes invalid post-validation.
+        """
+        config = self.CONFIG_CLASS("test", None)
+        # A sorted list of keys that are required, but have no default
+        target_keys = sorted(list(config._required_keys - set(config.defaults.keys())))
+        config_values = self._modified_dict(self.VALID_CONFIG, excluding=target_keys)
+        config.update(**config_values)
+
+        messages = config.validate()
+
+        self.assertEqual(config.state, ValidationState.INVALID)
+        self.assertTrue(any(message[0] == 'error' for message in messages))
+
+    def test_missing_required_with_default(self):
+        """
+        Test that a config section given a set of values which are valid other than missing required
+        keys which have defaults, will be valid post validation, and that the values for the
+        defaults are used.
+
+        NOTE: This does not account for modifications of default values made during validation.
+        """
+        config = self.CONFIG_CLASS("test", None)
+        target_keys = sorted(list(config._required_keys & set(config.defaults.keys())))
+        config_values = self._modified_dict(self.VALID_CONFIG, excluding=target_keys)
+        config.update(**config_values)
+
+        config.validate()
+
+        self.assertEqual(config.state, ValidationState.VALID)
+
+        for key in target_keys:
+            self.assertIn(key, config, "Key '%s' is missing from config")
+            self.assertEqual(config[key], config.defaults[key])

--- a/tests/base.py
+++ b/tests/base.py
@@ -74,8 +74,8 @@ class ConfigSectionValidationTests(object):
     # should be a list of the keys which are required
     REQUIRED_KEYS = set()
 
-    # Those keys that should have a default
-    KEYS_WITH_DEFAULTS = set()
+    # Those keys that should have a default (along with their expected default value)
+    DEFAULTS = {}
 
     def _modified_dict(self, values, excluding=None, including=None):
         """
@@ -137,7 +137,7 @@ class ConfigSectionValidationTests(object):
         """
         config = self.CONFIG_CLASS("test", None)
         # A sorted list of keys that are required, but have no default
-        target_keys = sorted(list(self.REQUIRED_KEYS - self.KEYS_WITH_DEFAULTS))
+        target_keys = sorted(list(self.REQUIRED_KEYS - set(self.DEFAULTS.keys())))
         config_values = self._modified_dict(self.VALID_CONFIG, excluding=target_keys)
         config.update(**config_values)
 
@@ -155,7 +155,7 @@ class ConfigSectionValidationTests(object):
         NOTE: This does not account for modifications of default values made during validation.
         """
         config = self.CONFIG_CLASS("test", None)
-        target_keys = sorted(list(self.REQUIRED_KEYS & self.KEYS_WITH_DEFAULTS))
+        target_keys = sorted(list(self.REQUIRED_KEYS & set(self.DEFAULTS.keys())))
         config_values = self._modified_dict(self.VALID_CONFIG, excluding=target_keys)
         config.update(**config_values)
 
@@ -165,4 +165,4 @@ class ConfigSectionValidationTests(object):
 
         for key in target_keys:
             self.assertIn(key, config, "Key '%s' is missing from config")
-            self.assertEqual(config[key], config.defaults[key])
+            self.assertEqual(config[key], self.DEFAULTS[key])

--- a/tests/test_config_section_esx.py
+++ b/tests/test_config_section_esx.py
@@ -39,3 +39,16 @@ class TestEsxConfigSection(ConfigSectionValidationTests, TestBase):
         "filter_host_parents": "'PARENT_A', 'PARENT_B'",
         "exclude_host_parents": "'PARENT_C_EXCLUDED'",
     }
+
+    REQUIRED_KEYS = set([
+        'type',
+        'server',
+        'username',
+        'password',
+    ])
+
+    KEYS_WITH_DEFAULTS = set([
+        'filter_host_parents',
+        'exclude_host_parents'
+    ])
+

--- a/tests/test_config_section_esx.py
+++ b/tests/test_config_section_esx.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+
+"""
+Test validating of EsxConfigSection
+"""
+
+from base import ConfigSectionValidationTests, TestBase
+from virtwho.virt.esx.esx import EsxConfigSection
+
+
+class TestEsxConfigSection(ConfigSectionValidationTests, TestBase):
+    """
+    A group of tests to ensure proper validation of EsxConfigSections
+    """
+    CONFIG_CLASS = EsxConfigSection
+    VALID_CONFIG = {
+        "type": "esx",
+        "server": "1.2.3.4",
+        "username": "username",
+        "password": "password",
+        "owner": "admin",
+        "env": "admin",
+        "filter_host_parents": "'PARENT_A', 'PARENT_B'",
+        "exclude_host_parents": "'PARENT_C_EXCLUDED'",
+    }

--- a/tests/test_config_section_esx.py
+++ b/tests/test_config_section_esx.py
@@ -21,6 +21,7 @@ Test validating of EsxConfigSection
 """
 
 from base import ConfigSectionValidationTests, TestBase
+from virtwho.parser import SAT6
 from virtwho.virt.esx.esx import EsxConfigSection
 
 
@@ -47,8 +48,11 @@ class TestEsxConfigSection(ConfigSectionValidationTests, TestBase):
         'password',
     ])
 
-    KEYS_WITH_DEFAULTS = set([
-        'filter_host_parents',
-        'exclude_host_parents'
-    ])
+    DEFAULTS = {
+        'filter_host_parents': None,
+        'exclude_host_parents': None,
+        'hypervisor_id': 'uuid',
+        'simplified_vim': True,
+        'sm_type': SAT6,
+    }
 

--- a/tests/test_config_section_hyperv.py
+++ b/tests/test_config_section_hyperv.py
@@ -45,3 +45,7 @@ class TestHyperVConfigSection(ConfigSectionValidationTests, TestBase):
         'password',
     ])
 
+    DEFAULTS = {
+        'hypervisor_id': 'uuid',
+        'sm_type': 'sam',
+    }

--- a/tests/test_config_section_hyperv.py
+++ b/tests/test_config_section_hyperv.py
@@ -37,3 +37,11 @@ class TestHyperVConfigSection(ConfigSectionValidationTests, TestBase):
         "owner": "admin",
         "env": "admin",
     }
+
+    REQUIRED_KEYS = set([
+        'type',
+        'server',
+        'username',
+        'password',
+    ])
+

--- a/tests/test_config_section_hyperv.py
+++ b/tests/test_config_section_hyperv.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+
+"""
+Test validating of HypervConfigSection
+"""
+
+from base import ConfigSectionValidationTests, TestBase
+from virtwho.virt.hyperv.hyperv import HypervConfigSection
+
+
+class TestHyperVConfigSection(ConfigSectionValidationTests, TestBase):
+    """
+    A group of tests to ensure proper validation of HyperVConfigSections
+    """
+    CONFIG_CLASS = HypervConfigSection
+    VALID_CONFIG = {
+        "type": "hyperv",
+        "server": "1.2.3.4",
+        "username": "username",
+        "password": "password",
+        "owner": "admin",
+        "env": "admin",
+    }

--- a/tests/test_config_section_xen.py
+++ b/tests/test_config_section_xen.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+
+"""
+Test validating of XenConfigSection
+"""
+
+from base import ConfigSectionValidationTests, TestBase
+from virtwho.virt.xen.xen import XenConfigSection
+
+
+class TestXenConfigSection(ConfigSectionValidationTests, TestBase):
+    """
+    A group of tests to ensure proper validation of XenConfigSections
+    """
+    CONFIG_CLASS = XenConfigSection
+    VALID_CONFIG = {
+        "type": "xen",
+        "server": "1.2.3.4",
+        "username": "username",
+        "password": "password",
+        "owner": "admin",
+        "env": "admin",
+    }

--- a/tests/test_config_section_xen.py
+++ b/tests/test_config_section_xen.py
@@ -37,3 +37,11 @@ class TestXenConfigSection(ConfigSectionValidationTests, TestBase):
         "owner": "admin",
         "env": "admin",
     }
+
+    REQUIRED_KEYS = set([
+        'type',
+        'server',
+        'username',
+        'password',
+    ])
+

--- a/tests/test_config_section_xen.py
+++ b/tests/test_config_section_xen.py
@@ -45,3 +45,8 @@ class TestXenConfigSection(ConfigSectionValidationTests, TestBase):
         'password',
     ])
 
+    DEFAULTS = {
+        'hypervisor_id': 'uuid',
+        'sm_type': 'sam',
+    }
+

--- a/virtwho/config.py
+++ b/virtwho/config.py
@@ -1011,7 +1011,7 @@ class VirtConfigSection(ConfigSection):
         """
         result = None
         sm_type = self._values['sm_type']
-        virt_type = self._values['type']
+        virt_type = self._values.get('type')
         if sm_type == 'sam' and (
                 (virt_type in ('esx', 'rhevm', 'hyperv', 'xen')) or
                 (virt_type == 'libvirt' and 'server' in self._values)):
@@ -1028,7 +1028,7 @@ class VirtConfigSection(ConfigSection):
         """
         result = None
         sm_type = self._values['sm_type']
-        virt_type = self._values['type']
+        virt_type = self._values.get('type')
         if sm_type == 'sam' and virt_type in ('esx', 'rhevm', 'hyperv', 'xen'):
             if key not in self:
                 result = (

--- a/virtwho/virt/esx/esx.py
+++ b/virtwho/virt/esx/esx.py
@@ -491,6 +491,9 @@ class EsxConfigSection(VirtConfigSection):
 
     def __init__(self, *args, **kwargs):
         super(EsxConfigSection, self).__init__(*args, **kwargs)
+        self.add_key('server', validation_method=self._validate_server, required=True)
+        self.add_key('username', validation_method=self._validate_username, required=True)
+        self.add_key('password', validation_method=self._validate_unencrypted_password, required=True)
         self.add_key('env', validation_method=self._validate_env, required=True)
         self.add_key('owner', validation_method=self._validate_owner, required=True)
         self.add_key('is_hypervisor', validation_method=self._validate_str_to_bool, default=True)


### PR DESCRIPTION
This modifies the EsxConfigSection to require the 'server', 'username', and 'password' options.

Esx requires these options to operate properly.

Bug fix: https://bugzilla.redhat.com/show_bug.cgi?id=1512778