### PR TITLE
1523548: Options log_dir and log_file are not ignored

### DIFF
--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -85,27 +85,22 @@ class TestLog(TestBase):
         mockQueueLogger = Mock(wraps=queueLogger)
         getQueueLogger.return_value = mockQueueLogger
 
-        config = Mock()
-        config.name = 'test'
-        config.log_file = 'test.log'
-        config.log_dir = '/test/'
-
         options = {
             'global':{
                 'debug': False,
                 'background': True,
                 'log_per_config': True,
-                'log_dir': '',
-                'log_file': '',
+                'log_dir': '/test/',
+                'log_file': 'test.log',
             },
         }
         log.init(options)
-        test_logger = log.getLogger(name='test', config=config)
+        test_logger = log.getLogger(config=options)
 
-        self.assertTrue(test_logger.name == 'virtwho.test')
+        self.assertTrue(test_logger.name == 'virtwho.test_log')
         self.assertTrue(len(test_logger.handlers) == 1)
         self.assertTrue(len(queueLogger.logger.handlers) == 1)
-        getFileHandler.assert_called_with(name=test_logger.name, config=config)
+        getFileHandler.assert_called_with(name=test_logger.name, config=options)
 
     @patch('os.path.isdir')
     @patch('logging.FileHandler._open')

--- a/virtwho/config.py
+++ b/virtwho/config.py
@@ -36,7 +36,7 @@ except ImportError:
     from util import OrderedDict
 
 # Module-level logger
-logger = log.getLogger('config', queue=False)
+logger = log.getLogger(name='config', queue=False)
 
 _effective_config = None
 
@@ -1346,9 +1346,11 @@ def init_config(env_options, cli_options, config_dir=VW_CONF_DIR):
     # Validate GlobalSection before use.
     effective_config[VW_GLOBAL].validate()
 
+    # Close existing logger
+    log.closeLogger(logger)
     # Initialize logger, the creation of this object is the earliest it can be done
     log.init(effective_config)
-    logger = log.getLogger('config', queue=False)
+    logger = log.getLogger(config=effective_config, queue=False)
 
     # Create the effective env / cli config from those values we've sorted out as non_global
     env_cli_sources = [env_non_globals, cli_non_globals]

--- a/virtwho/executor.py
+++ b/virtwho/executor.py
@@ -58,8 +58,7 @@ class Executor(object):
         virts = []
         for name, config in self.dest_to_source_mapper.configs:
             try:
-                logger = log.getLogger(config=config)
-                virt = Virt.from_config(logger, config, self.datastore,
+                virt = Virt.from_config(self.logger, config, self.datastore,
                                         terminate_event=self.terminate_event,
                                         interval=self.options[VW_GLOBAL]['interval'],
                                         oneshot=self.options[VW_GLOBAL]['oneshot'])

--- a/virtwho/log.py
+++ b/virtwho/log.py
@@ -192,8 +192,8 @@ class Logger(object):
     @classmethod
     def get_logger(cls, name=None, config=None, queue=True):
         if name is None:
-            # Remove slashes and periods in the config.name (as that could mess logging up
-            name = config.name.replace('.', '').replace('/', '_') if config else 'main'
+            # Remove slashes and periods in the log_file (as that could mess logging up
+            name = config['global']['log_file'].replace('.', '_').replace('/', '_') if config else 'main'
         virt_who_logger_name = 'virtwho.' + name  # The name of the logger instance
 
         try:
@@ -262,7 +262,7 @@ class Logger(object):
     @classmethod
     def get_file_handler(cls, name, config=None):
         if cls._log_per_config:
-            log_file = getattr(config, 'log_file', None) or (name + '.log')
+            log_file = name + '.log'
         else:
             log_file = cls._log_file
 

--- a/virtwho/main.py
+++ b/virtwho/main.py
@@ -169,8 +169,7 @@ def main():
         signal.signal(signal.SIGHUP, reload)
         signal.signal(signal.SIGTERM, atexit_fn)
 
-        executor.logger = logger = log.getLogger(name='main', config=None,
-                                                 queue=True)
+        executor.logger = logger = log.getLogger(name='main', queue=True)
 
         sd_notify("READY=1\nMAINPID=%d" % os.getpid())
         while True:

--- a/virtwho/parser.py
+++ b/virtwho/parser.py
@@ -494,7 +494,7 @@ def parse_options():
     # Ensure validation errors during effective config creation are logged
     errors.extend(effective_config.validation_messages)
 
-    logger = log.getLogger("init", queue=False)
+    logger = log.getLogger(config=effective_config, queue=False)
 
     used_deprecated_cli_options = []
     for option in DEPRECATED_OPTIONS:


### PR DESCRIPTION
* Bug fix: https://bugzilla.redhat.com/show_bug.cgi?id=1523548
* When following options are set:

```
[global]
log_dir = /some/path
log_file = my_file.log
```

  then all messages are printed to file /some/path/my_file.log and not to /var/log/rhsm/rhsm.log (default value).