### PR TITLE
1520236: Do not log traceback, when server returns 429 http error

### DIFF
--- a/virtwho/manager/subscriptionmanager/subscriptionmanager.py
+++ b/virtwho/manager/subscriptionmanager/subscriptionmanager.py
@@ -198,6 +198,8 @@ class SubscriptionManager(Manager):
                 raise SubscriptionManagerError(
                     "Unable to obtain status from server, UEPConnection is likely not usable."
                 )
+        except rhsm_connection.RateLimitExceededException as e:
+            raise ManagerThrottleError(e.retry_after)
         except BadStatusLine:
             raise ManagerError("Communication with subscription manager interrupted")
 
@@ -229,8 +231,7 @@ class SubscriptionManager(Manager):
         except rhsm_connection.GoneException:
             raise ManagerError("Communication with subscription manager failed: consumer no longer exists")
         except rhsm_connection.RateLimitExceededException as e:
-            retry_after = int(getattr(e, 'headers', {}).get('Retry-After', '60'))
-            raise ManagerThrottleError(retry_after)
+            raise ManagerThrottleError(e.retry_after)
         report.state = AbstractVirtReport.STATE_FINISHED
 
     def hypervisorCheckIn(self, report, options=None):
@@ -269,8 +270,7 @@ class SubscriptionManager(Manager):
         except BadStatusLine:
             raise ManagerError("Communication with subscription manager interrupted")
         except rhsm_connection.RateLimitExceededException as e:
-            retry_after = int(getattr(e, 'headers', {}).get('Retry-After', '60'))
-            raise ManagerThrottleError(retry_after)
+            raise ManagerThrottleError(e.retry_after)
         except rhsm_connection.GoneException:
             raise ManagerError("Communication with subscription manager failed: consumer no longer exists")
         except rhsm_connection.ConnectionException as e:

--- a/virtwho/virt/virt.py
+++ b/virtwho/virt/virt.py
@@ -708,15 +708,18 @@ class DestinationThread(IntervalThread):
                         retry = False
                     except ManagerThrottleError as e:
                         if self._oneshot:
-                            self.logger.debug('429 encountered when sending virt guests in '
-                                              'oneshot mode, not retrying')
+                            self.logger.info(
+                                'Rate limit exceeded while sending host-guest mapping, please see: '
+                                'https://access.redhat.com/solutions/2212941. '
+                                'Running in one-shot mode, not retrying.')
                             sources_erred.append(source_key)
                             break
                         num_429_received += 1
                         retry_after = self.handle_429(e.retry_after, num_429_received)
-                        self.logger.debug('429 encountered when sending virt '
-                                          'guests.'
-                                          'Retrying after: %s', retry_after)
+                        self.logger.info(
+                            'Rate limit exceeded while sending host-guest mapping, please see: '
+                            'https://access.redhat.com/solutions/2212941. '
+                            'Retrying after: %s seconds.', retry_after)
                         self.wait(wait_time=retry_after)
                     except (ManagerError, ManagerFatalError):
                         self.logger.exception("Fatal error during send virt "


### PR DESCRIPTION
* Bug fix: https://bugzilla.redhat.com/show_bug.cgi?id=1520236
* When rate limit exceeded, then catch this exception and reraise
  different exception. This is handled properly in virt.py
* Raised log level for this case from debug to info, because
  user should be informed why is communication broken with
  candlepin server.