### PR TITLE
1492074: Enable login to ESX using password with UTF-8 string

### DIFF
--- a/tests/test_config_section_virt.py
+++ b/tests/test_config_section_virt.py
@@ -206,7 +206,7 @@ class TestVirtConfigSection(TestBase):
         """
         self.init_virt_config_section()
         # First, change username to something exotic ;-)
-        self.virt_config['username'] = u'Jiří'
+        self.virt_config['username'] = 'Jiří'
         result = self.virt_config._validate_username('username')
         self.assertIsNotNone(result)
 

--- a/tests/test_esx.py
+++ b/tests/test_esx.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """
 Test of ESX virtualization backend.
 
@@ -17,6 +19,7 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 """
+
 import os
 import requests
 import suds
@@ -69,6 +72,20 @@ class TestEsx(TestBase):
         mock_client.assert_called_with(ANY, location="https://localhost/sdk", cache=None, transport=ANY)
         mock_client.return_value.service.RetrieveServiceContent.assert_called_once_with(_this=ANY)
         mock_client.return_value.service.Login.assert_called_once_with(_this=ANY, userName='username', password='password')
+
+    @patch('suds.client.Client')
+    def test_connect_utf_password(self, mock_client):
+        mock_client.return_value.service.WaitForUpdatesEx.return_value = None
+        # Change password to include some UTF character
+        self.esx.password = 'Žluťoučký_kůň'
+        self.run_once()
+
+        self.assertTrue(mock_client.called)
+        mock_client.assert_called_with(ANY, location="https://localhost/sdk", cache=None, transport=ANY)
+        mock_client.return_value.service.RetrieveServiceContent.assert_called_once_with(_this=ANY)
+        mock_client.return_value.service.Login.assert_called_once_with(
+            _this=ANY, userName='username', password=u'Žluťoučký_kůň'
+        )
 
     @patch('suds.client.Client')
     def test_connection_timeout(self, mock_client):

--- a/virtwho/config.py
+++ b/virtwho/config.py
@@ -1030,11 +1030,11 @@ class VirtConfigSection(ConfigSection):
             if username != NotSetSentinel:
                 try:
                     username.encode('latin1')
-                except UnicodeEncodeError:
+                except (UnicodeEncodeError, UnicodeDecodeError):
                     result = (
                         'warning',
                         "Value: {0} of option '{1}': is not in latin1 encoding".format(
-                            username.encode('utf-8'),
+                            username,
                             username_key
                         )
                     )

--- a/virtwho/virt/esx/esx.py
+++ b/virtwho/virt/esx/esx.py
@@ -339,7 +339,11 @@ class Esx(virt.Virt):
         try:
             # Don't log message containing password
             logging.getLogger('suds.client').setLevel(logging.CRITICAL)
-            self.client.service.Login(_this=self.sc.sessionManager, userName=self.username, password=self.password)
+            self.client.service.Login(
+                _this=self.sc.sessionManager,
+                userName=unicode(self.username, 'utf-8'),
+                password=unicode(self.password, 'utf-8')
+            )
             logging.getLogger('suds.client').setLevel(logging.ERROR)
         except requests.RequestException as e:
             raise virt.VirtError(str(e))


### PR DESCRIPTION
* Bug fix: https://bugzilla.redhat.com/show_bug.cgi?id=1492074
* Module suds does not allow to use password as latin string or
  unicode. It does not allow to use string with UTF-8 characters.