### PR TITLE
1387800: [RFE] virt-who can report cluster in host-to-guest mapping

### DIFF
--- a/tests/complex/data/esx/esx_waitforupdatesexresponse_0.xml
+++ b/tests/complex/data/esx/esx_waitforupdatesexresponse_0.xml
@@ -79,7 +79,7 @@
                         <changeSet>
                             <name>parent</name>
                             <op>assign</op>
-                            <val type="ComputeResource" xsi:type="ManagedObjectReference">ha-compute-res</val>
+                            <val type="ClusterComputeResource" xsi:type="ManagedObjectReference">ha-compute-res</val>
                         </changeSet>
                         <changeSet>
                             <name>vm</name>
@@ -122,7 +122,7 @@
                         <changeSet>
                             <name>parent</name>
                             <op>assign</op>
-                            <val type="ComputeResource" xsi:type="ManagedObjectReference">ha-compute-res</val>
+                            <val type="ClusterComputeResource" xsi:type="ManagedObjectReference">ha-compute-res</val>
                         </changeSet>
                         <changeSet>
                             <name>vm</name>
@@ -161,7 +161,7 @@
                         <changeSet>
                             <name>parent</name>
                             <op>assign</op>
-                            <val type="ComputeResource" xsi:type="ManagedObjectReference">ha-compute-res</val>
+                            <val type="ClusterComputeResource" xsi:type="ManagedObjectReference">ha-compute-res</val>
                         </changeSet>
                         <changeSet>
                             <name>vm</name>

--- a/tests/complex/data/esx/esx_waitforupdatesexresponse_1.xml
+++ b/tests/complex/data/esx/esx_waitforupdatesexresponse_1.xml
@@ -74,7 +74,7 @@
                         <changeSet>
                             <name>parent</name>
                             <op>assign</op>
-                            <val type="ComputeResource" xsi:type="ManagedObjectReference">ha-compute-res</val>
+                            <val type="ClusterComputeResource" xsi:type="ManagedObjectReference">ha-compute-res</val>
                         </changeSet>
                         <changeSet>
                             <name>vm</name>
@@ -111,7 +111,7 @@
                         <changeSet>
                             <name>parent</name>
                             <op>assign</op>
-                            <val type="ComputeResource" xsi:type="ManagedObjectReference">ha-compute-res</val>
+                            <val type="ClusterComputeResource" xsi:type="ManagedObjectReference">ha-compute-res</val>
                         </changeSet>
                         <changeSet>
                             <name>vm</name>
@@ -147,7 +147,7 @@
                         <changeSet>
                             <name>parent</name>
                             <op>assign</op>
-                            <val type="ComputeResource" xsi:type="ManagedObjectReference">ha-compute-res</val>
+                            <val type="ClusterComputeResource" xsi:type="ManagedObjectReference">ha-compute-res</val>
                         </changeSet>
                         <changeSet>
                             <name>vm</name>

--- a/tests/complex/data/rhevm/rhevm_clusters.xml
+++ b/tests/complex/data/rhevm/rhevm_clusters.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <clusters>
     <cluster href="/api/clusters/be0fa062-3be0-461a-bf43-ff7579c473e4" id="be0fa062-3be0-461a-bf43-ff7579c473e4">
-        <name>Cetus</name>
+        <name>ha-compute-res-01</name>
         <link href="/api/clusters/be0fa062-3be0-461a-bf43-ff7579c473e4/networks" rel="networks"/>
         <link href="/api/clusters/be0fa062-3be0-461a-bf43-ff7579c473e4/permissions" rel="permissions"/>
         <link href="/api/clusters/be0fa062-3be0-461a-bf43-ff7579c473e4/glustervolumes" rel="glustervolumes"/>
@@ -55,7 +55,7 @@
         <required_rng_sources/>
     </cluster>
     <cluster href="/api/clusters/166b99a7-a40c-4823-8960-749a8985cd9d" id="166b99a7-a40c-4823-8960-749a8985cd9d">
-        <name>CL32</name>
+        <name>ha-compute-res-02</name>
         <link href="/api/clusters/166b99a7-a40c-4823-8960-749a8985cd9d/networks" rel="networks"/>
         <link href="/api/clusters/166b99a7-a40c-4823-8960-749a8985cd9d/permissions" rel="permissions"/>
         <link href="/api/clusters/166b99a7-a40c-4823-8960-749a8985cd9d/glustervolumes" rel="glustervolumes"/>

--- a/tests/complex/virtwhotest.py
+++ b/tests/complex/virtwhotest.py
@@ -233,6 +233,9 @@ class VirtBackendTestMixin(object):
         code, out = self.run_virtwho(self.arguments + ['-p', '--debug'], grab_stdout=True)
         self.assertEqual(code, 0, "virt-who exited with wrong error code: %s" % code)
         returned = json.loads(out)
+        # Test facts
+        for hypervisor in returned['hypervisors']:
+            self.assertTrue(hypervisor['facts']['hypervisor.cluster'].startswith('ha-compute-res'))
         # Transform it to the same format as assoc from SAM server
         assoc = dict((host['uuid'], host['guests']) for host in returned['hypervisors'])
         self.check_assoc(assoc, {

--- a/tests/test_esx.py
+++ b/tests/test_esx.py
@@ -119,6 +119,7 @@ class TestEsx(TestBase):
 
         fake_parent = MagicMock()
         fake_parent.value = 'Fake_parent'
+        fake_parent._type = 'ClusterComputeResource'
 
         fake_vm_id = MagicMock()
         fake_vm_id.value = 'guest1'
@@ -136,7 +137,7 @@ class TestEsx(TestBase):
                      'hardware.cpuInfo.numCpuPackages': '1',
                      'name': expected_hostname,
                      'parent': fake_parent,
-                     'vm': fake_vm
+                     'vm': fake_vm,
                      }
         fake_hosts = {'random-host-id': fake_host}
         self.esx.hosts = fake_hosts
@@ -155,6 +156,7 @@ class TestEsx(TestBase):
                 Hypervisor.CPU_SOCKET_FACT: '1',
                 Hypervisor.HYPERVISOR_TYPE_FACT: 'vmware',
                 Hypervisor.HYPERVISOR_VERSION_FACT: '1.2.3',
+                Hypervisor.HYPERVISOR_CLUSTER: 'Fake_parent',
             }
         )
         result = self.esx.getHostGuestMapping()['hypervisors'][0]

--- a/tests/test_rhevm.py
+++ b/tests/test_rhevm.py
@@ -182,6 +182,7 @@ class TestRhevM(TestBase):
                 Hypervisor.CPU_SOCKET_FACT: '1',
                 Hypervisor.HYPERVISOR_TYPE_FACT: 'qemu',
                 Hypervisor.HYPERVISOR_VERSION_FACT: '1.2.3',
+                Hypervisor.HYPERVISOR_CLUSTER: 'Cetus',
             }
         )
         result = self.rhevm.getHostGuestMapping()['hypervisors'][0]
@@ -226,6 +227,7 @@ class TestRhevM(TestBase):
                 Hypervisor.CPU_SOCKET_FACT: '1',
                 Hypervisor.HYPERVISOR_TYPE_FACT: 'qemu',
                 Hypervisor.HYPERVISOR_VERSION_FACT: '1.2.3',
+                Hypervisor.HYPERVISOR_CLUSTER: 'Cetus',
             }
         )
         result = self.rhevm.getHostGuestMapping()['hypervisors'][0]

--- a/virtwho/virt/esx/esx.py
+++ b/virtwho/virt/esx/esx.py
@@ -303,6 +303,10 @@ class Esx(virt.Virt):
                 virt.Hypervisor.CPU_SOCKET_FACT: str(host['hardware.cpuInfo.numCpuPackages']),
                 virt.Hypervisor.HYPERVISOR_TYPE_FACT: host.get('config.product.name', 'vmware'),
             }
+
+            if host['parent'] and host['parent']._type == 'ClusterComputeResource':
+                facts[virt.Hypervisor.HYPERVISOR_CLUSTER] = host['parent'].value
+
             version = host.get('config.product.version', None)
             if version:
                 facts[virt.Hypervisor.HYPERVISOR_VERSION_FACT] = version

--- a/virtwho/virt/rhevm/rhevm.py
+++ b/virtwho/virt/rhevm/rhevm.py
@@ -212,6 +212,7 @@ class RhevM(virt.Virt):
         mapping = {}
         hosts = {}
         clusters = set()
+        cluster_names = {}
 
         clusters_xml = self.get_xml(self.clusters_url)
         hosts_xml = self.get_xml(self.hosts_url)
@@ -221,6 +222,7 @@ class RhevM(virt.Virt):
         for cluster in clusters_xml.findall('cluster'):
             cluster_id = cluster.get('id')
             virt_service = cluster.find('virt_service').text
+            cluster_names[cluster_id] = cluster.find('name').text
             if virt_service.lower() == 'true':
                 clusters.add(cluster_id)
 
@@ -257,6 +259,14 @@ class RhevM(virt.Virt):
                 virt.Hypervisor.CPU_SOCKET_FACT: sockets,
                 virt.Hypervisor.HYPERVISOR_TYPE_FACT: 'qemu',
             }
+
+            try:
+                cluster_name = cluster_names[host_cluster_id]
+            except KeyError:
+                pass
+            else:
+                facts[virt.Hypervisor.HYPERVISOR_CLUSTER] = cluster_name
+
             try:
                 version = host.find('version').get('full_version')
                 if version:

--- a/virtwho/virt/virt.py
+++ b/virtwho/virt/virt.py
@@ -104,6 +104,7 @@ class Hypervisor(object):
     CPU_SOCKET_FACT = 'cpu.cpu_socket(s)'
     HYPERVISOR_TYPE_FACT = 'hypervisor.type'
     HYPERVISOR_VERSION_FACT = 'hypervisor.version'
+    HYPERVISOR_CLUSTER = 'hypervisor.cluster'
 
     def __init__(self, hypervisorId, guestIds=None, name=None, facts=None):
         """


### PR DESCRIPTION
* Bug fix: https://bugzilla.redhat.com/show_bug.cgi?id=1387800
* Virt-who can report information about cluster, when ESX or
  RHEV is used. It is mostly usefull, when you run virt-who
  with --print parameter. You can get something like this:

    ....
    "facts": {
        "hypervisor.type": "qemu",
        "hypervisor.version": "vdsm-4.19.49-1.el7ev",
        "hypervisor.cluster": "Default", <---- cluster name
        "cpu.cpu_socket(s)": "1"
    }
    ...

* User can easilly see cluster name of hyperviros host
* Updated unit test for ESX and RHEV