### PR TITLE
1554228: Unicode issue on status update call

### DIFF
--- a/virtwho/manager/subscriptionmanager/subscriptionmanager.py
+++ b/virtwho/manager/subscriptionmanager/subscriptionmanager.py
@@ -326,7 +326,8 @@ class SubscriptionManager(Manager):
         return serialized_mapping
 
     def check_report_state(self, report):
-        job_id = report.job_id
+        # BZ 1554228
+        job_id = str(report.job_id)
         self._connect(report.config)
         self.logger.debug('Checking status of job %s', job_id)
         try:


### PR DESCRIPTION
How to test this issue:

Start on master branch and use the  QE instance of rhevm4. Ask for the credentials if you need them.

Run the following as root [not sudo]
run 'virt-who -do', it should work properly.
run 'export RHSM_USE_M2CRYPTO=true'
run 'virt-who -do', it should fail as is described in the bug.

Change to this branch
run 'virt-who -do', it should work properly.
