### PR TITLE
Update tito releasers to include newer versions of fedora

### DIFF
--- a/rel-eng/releasers.conf
+++ b/rel-eng/releasers.conf
@@ -1,6 +1,6 @@
 [fedora]
 releaser = tito.release.FedoraGitReleaser
-branches = master f21 f20
+branches = master f28 f27 f26
 
 [rhel-7.2]
 releaser = tito.release.DistGitReleaser


### PR DESCRIPTION
This updates the branches into which we'd like to release virt-who for fedora.
We should be targeting the same as subscription-manager in my opinion.