### PR TITLE
1569299: try/exception needed for hypervisor_id check

### DIFF
--- a/tests/complex/data/esx/esx_waitforupdatesexresponse_0.xml
+++ b/tests/complex/data/esx/esx_waitforupdatesexresponse_0.xml
@@ -169,6 +169,40 @@
                             <val xsi:type="ArrayOfManagedObjectReference"></val>
                         </changeSet>
                     </objectSet>
+                    <objectSet>
+                        <kind>enter</kind>
+                        <obj type="HostSystem">ha-host4</obj>
+                        <changeSet>
+                            <name>hardware.cpuInfo.numCpuPackages</name>
+                            <op>assign</op>
+                            <val xsi:type="xsd:short">1</val>
+                        </changeSet>
+                        <changeSet>
+                            <name>config.network.dnsConfig.hostName</name>
+                            <op>assign</op>
+                            <val xsi:type="xsd:string">localhost百度</val>
+                        </changeSet>
+                        <changeSet>
+                            <name>config.network.dnsConfig.domainName</name>
+                            <op>assign</op>
+                            <val xsi:type="xsd:string">localdomain</val>
+                        </changeSet>
+                        <changeSet>
+                            <name>name</name>
+                            <op>assign</op>
+                            <val xsi:type="xsd:string">localhost百度.localdomain</val>
+                        </changeSet>
+                        <changeSet>
+                            <name>parent</name>
+                            <op>assign</op>
+                            <val type="ClusterComputeResource" xsi:type="ManagedObjectReference">ha-compute-res</val>
+                        </changeSet>
+                        <changeSet>
+                            <name>vm</name>
+                            <op>assign</op>
+                            <val xsi:type="ArrayOfManagedObjectReference"></val>
+                        </changeSet>
+                    </objectSet>
                 </filterSet>
             </returnval>
         </WaitForUpdatesExResponse>

--- a/virtwho/virt/esx/esx.py
+++ b/virtwho/virt/esx/esx.py
@@ -258,15 +258,20 @@ class Esx(virt.Virt):
                 continue
             guests = []
 
-            if self.config['hypervisor_id'] == 'uuid':
-                uuid = host['hardware.systemInfo.uuid']
-            elif self.config['hypervisor_id'] == 'hwuuid':
-                uuid = host_id
-            elif self.config['hypervisor_id'] == 'hostname':
-                uuid = host['config.network.dnsConfig.hostName']
-                domain_name = host['config.network.dnsConfig.domainName']
-                if domain_name:
-                    uuid = self._format_hostname(uuid, domain_name)
+            try:
+                if self.config['hypervisor_id'] == 'uuid':
+                    uuid = host['hardware.systemInfo.uuid']
+                elif self.config['hypervisor_id'] == 'hwuuid':
+                    uuid = host_id
+                elif self.config['hypervisor_id'] == 'hostname':
+                    uuid = host['config.network.dnsConfig.hostName']
+                    domain_name = host['config.network.dnsConfig.domainName']
+                    if domain_name:
+                        uuid = self._format_hostname(uuid, domain_name)
+            except KeyError:
+                self.logger.debug("Host '%s' doesn't have hypervisor_id property", host_id)
+                continue
+
             if host['vm']:
                 for vm_id in host['vm'].ManagedObjectReference:
                     if vm_id.value not in self.vms:


### PR DESCRIPTION
Otherwise the process of reading system data fails if only one
 system does not have a value for the field designated as the
 hypervisor id.