### PR TITLE
1542652: When the -c option is used, don't parse the default files

### DIFF
--- a/virt-who.8
+++ b/virt-who.8
@@ -21,7 +21,7 @@ Acquire and send guest information each N seconds; note that this option is reco
 Print the host/guests association in JSON format to standard output
 .TP
 \fB\-c\fR, \fB\-\-config\fR
-Use configuration file directly, can be used multiple times. See virt-who-config(5) for details about configuration file format.
+Use configuration file directly (will override configuration from other files. 'global' and 'default' sections are not read in files passed in via this option, and are only read from /etc/virt-who.conf). Can be used multiple times. See virt-who-config(5) for details about configuration file format.
 .IP
 .SS Virtualization backend
 .IP

--- a/virtwho/parser.py
+++ b/virtwho/parser.py
@@ -317,7 +317,10 @@ def parse_cli_arguments():
     parser.add_argument("-p", "--print", action="store_true", dest="print_", default=False,
                         help="Print the host/guest association obtained from virtualization backend (implies oneshot)")
     parser.add_argument("-c", "--config", action="append", dest="configs", default=[],
-                        help="Configuration file that will be processed, can be used multiple times")
+                        help="Configuration file that will be processed and will override configuration \n"
+                             "from other files. 'global' and 'default' sections are not read in files passed in via \n"
+                             "this option, and are only read from /etc/virt-who.conf.\n"
+                             " Can be used multiple times")
     parser.add_argument("-m", "--log-per-config", action="store_true", dest="log_per_config", default=NotSetSentinel(),
                         help="[Deprecated] Write one log file per configured virtualization backend.\n"
                              "Implies a log_dir of %s/virtwho (Default: all messages are written to a single log file)"


### PR DESCRIPTION
- Now, when config files are passed through the cli -c option, configurations
in /etc/virt-who.conf and /etc/virt-who.d/* are not parsed.
- 'global' and 'default' sections are not parsed from files passed through
the -c option, but they will still be read from /etc/virt-who.conf.
- 'global' and 'default' sections are not parsed from /etc/virt-who.d/*