### PR TITLE
Set up Travis CI to use Python 3.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,14 @@
 language: python
 python:
   - "2.7"
+  - "3.6"
 env:
   - PYTHONPATH=.
 sudo: required
 dist: trusty
 install:
   - pip install -r requirements.txt
-  - pip install -U iniparse python-dateutil M2Crypto "libvirt-python<=4.0.0" unittest2 pytest-timeout mock
+  - pip install -U python-dateutil M2Crypto "libvirt-python<=4.0.0" unittest2 pytest-timeout mock
 script: py.test --timeout=30 -v
 before_install:
   - sudo apt-get update -qq

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # virt-who
 
-[![Build Status](https://travis-ci.org/virt-who/virt-who.svg?branch=master)](https://travis-ci.org/virt-who/virt-who)
+[![Build Status](https://travis-ci.org/candlepin/virt-who.svg?branch=master)](https://travis-ci.org/candlepin/virt-who)
 
 virt-who is agent for reporting virtual guest IDs to subscription manager.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,8 @@
 suds-py3;python_version>="3.0"
 suds;python_version<"3.0"
 git+https://github.com/candlepin/python-rhsm#egg=rhsm
+git+https://github.com/candlepin/python-iniparse#egg=iniparse;python_version>="3.0"
+iniparse;python_version<"3.0"
 requests>=2.0
 m2crypto;python_version<"3.0"
 six


### PR DESCRIPTION
* Unit tests are started for Python 2.7 and Python 3.6 too.
* It was necessary to create own repository for python-iniparse,
  because iniparse module is installed with pip. The last version
  of iniparse is 0.4 and it is 8 years old without support for
  Python 3.
  - Repository of iniparse compatible with Python 3 is available
    here: https://github.com/candlepin/python-iniparse
* Fixed link to badge icon in README.md