### PR TITLE
1455062: Partial fix of high CPU usage, when many conf files used

### DIFF
--- a/tests/test_datastore.py
+++ b/tests/test_datastore.py
@@ -10,8 +10,10 @@ class TestDatastore(TestBase):
     def setUp(self):
         copy_patcher = patch('virtwho.datastore.copy')
         self.mock_copy = copy_patcher.start()
-        self.mock_copy.deepcopy.side_effect = [sentinel.deep_copy_value_1,
-                                                sentinel.deep_copy_value_2]
+        self.mock_copy.deepcopy.side_effect = [
+            sentinel.deep_copy_value_1,
+            sentinel.deep_copy_value_2
+        ]
         self.addCleanup(copy_patcher.stop)
 
         lock_patcher = patch('virtwho.datastore.Lock')
@@ -99,8 +101,7 @@ class TestDatastore(TestBase):
         with patch.dict(datastore._datastore,
                         test_item=sentinel.test_item_value):
             result = datastore.get("test_item")
-        self.mock_copy.deepcopy.assert_called_with(sentinel.test_item_value)
-        self.assertEqual(result, sentinel.deep_copy_value_1)
+        self.assertEqual(result, sentinel.test_item_value)
 
     def test_put_locking(self):
         # Ensure that a lock is acquired before (and released after) updating a

--- a/virtwho/__main__.py
+++ b/virtwho/__main__.py
@@ -25,12 +25,10 @@ def main():
         logger.debug("virt-who terminated")
         virtwho.main.exit(res)
     finally:
-        # Work around multiprocessing not cleaning up after itself.
-        # http://bugs.python.org/issue4106
-        gc.collect()
         for x in threading.enumerate():
             if x.name == 'QueueFeederThread' and x.ident is not None:
                 x.join(1)
+
 
 if __name__ == '__main__':
     main()

--- a/virtwho/datastore.py
+++ b/virtwho/datastore.py
@@ -33,21 +33,21 @@ class Datastore(object):
     def put(self, key, value):
         """
         Stores the value, retrievable by key, in a threadsafe manner in the
-        underlying datastore. (Assumes all items are pickleable)
+        underlying datastore.
 
         @param key: The unique identifier for this value
         @type  key: str
 
         @param value: The object to store
         """
+        to_store = copy.deepcopy(value)
         with self._datastore_lock:
-            to_store = copy.deepcopy(value)
             self._datastore[key] = to_store
 
     def get(self, key, default=None):
         """
         Retrieves the value for the given key, in a threadsafe manner from the
-        underlying datastore. (Assumes all items in the datastore are pickled)
+        underlying datastore.
 
         @param key: The unique identifier for this value
         @type  key: str
@@ -60,8 +60,7 @@ class Datastore(object):
         """
         with self._datastore_lock:
             try:
-                item = copy.deepcopy(self._datastore[key])
-                return item
+                return self._datastore[key]
             except KeyError:
                 if default:
                     return default

--- a/virtwho/executor.py
+++ b/virtwho/executor.py
@@ -118,6 +118,7 @@ class Executor(object):
         not quit yet.
         @rtype: list
         """
+        delta_time = 1.0
         total_waited = 0
         threads_not_terminated = list(threads)
         while len(threads_not_terminated) > 0:
@@ -131,9 +132,9 @@ class Executor(object):
                     threads_not_terminated.remove(thread)
             if not threads_not_terminated:
                 break
-            time.sleep(1)
+            time.sleep(delta_time)
             if max_wait_time is not None:
-                total_waited += 1
+                total_waited += 1 * 1.0/delta_time
         return threads_not_terminated
 
     @staticmethod

--- a/virtwho/log.py
+++ b/virtwho/log.py
@@ -111,9 +111,8 @@ class QueueLogger(object):
 
     @staticmethod
     def _log(logger, queue):
-        exit = False
-        while not exit:
-            record = None
+        want_exit = False
+        while not want_exit:
             try:
                 record = queue.get()
             except Empty:
@@ -123,7 +122,7 @@ class QueueLogger(object):
                 if to_log:
                     logger.handle(to_log)
             else:
-                exit = True
+                want_exit = True
 
     def start_logging(self):
         self._logging_thread.start()

--- a/virtwho/virt/virt.py
+++ b/virtwho/virt/virt.py
@@ -302,16 +302,19 @@ class IntervalThread(Thread):
         self.terminate_event = terminate_event or self._internal_terminate_event
         self.interval = interval
         self._oneshot = oneshot
+        self.delta_time = 1.0
         super(IntervalThread, self).__init__()
 
     def wait(self, wait_time):
-        '''
+        """
         Wait `wait_time` seconds, could be interrupted by setting _terminate_event or _internal_terminate_event.
-        '''
-        for i in range(wait_time):
+        """
+        total_time = 0.0
+        while total_time < wait_time:
             if self.is_terminated():
                 break
-            time.sleep(1)
+            time.sleep(self.delta_time)
+            total_time += self.delta_time
 
     def is_terminated(self):
         """


### PR DESCRIPTION
* Bug fix: https://bugzilla.redhat.com/show_bug.cgi?id=1455062
* Removed unused gc.collect(), because virt-who is not mulitprocess anymore.
* It is not necessary to do deepcopy twice. Deep copy is probably the
  biggest reason of high CPU load.
* Do not do deepcopy, when datastore is locked.
* Do not use exit for name of variable.
* Added delta_time for testing of granularity of sleeping.
* TODO: Do not use deepcopy, when host-to-quest mapping is added to
  datastore, but add there only necessary informations.