### PR TITLE
1510920: Change the timing for the job status check

### DIFF
--- a/tests/test_virt.py
+++ b/tests/test_virt.py
@@ -291,32 +291,13 @@ class TestDestinationThread(TestBase):
         data_to_send = {'source1': report1,
                         'source2': report2}
         source_keys = ['source1', 'source2']
-        batch_report1 = Mock()  # The "report" to return from hypervisorCheckIn
+        batch_report1 = Mock()  # The "report" to check status
         batch_report1.state = AbstractVirtReport.STATE_CREATED
         datastore = {'source1': report1, 'source2': report2}
         manager = Mock()
-        manager.hypervisorCheckIn.return_value = batch_report1
+        items = [ManagerThrottleError(), ManagerThrottleError(), ManagerThrottleError(), AbstractVirtReport.STATE_FINISHED]
+        manager.check_report_state = Mock(side_effect=self.check_report_state_closure(items))
 
-        # A closure to allow us to have a function that "modifies" the given
-        # report in a predictable way.
-        # In this case I want to set the state of the report to STATE_FINISHED
-        # after the first try
-        def check_report_state_closure():
-            # The local variables we'd like to use to keep track of state
-            # must be in a dict (or some other mutable container) as all
-            # references in the enclosing scope in python 2.X are read-only
-            local_variables = {'count': 0}
-
-            def mock_check_report_state(report):
-                if local_variables['count'] > 1:
-                    report.state = AbstractVirtReport.STATE_FINISHED
-                else:
-                    report.state = AbstractVirtReport.STATE_CREATED
-                    local_variables['count'] += 1
-                return report
-            return mock_check_report_state
-        check_report_mock = check_report_state_closure()
-        manager.check_report_state = Mock(side_effect=check_report_mock)
         logger = Mock()
         config, d = self.create_fake_config('test', **self.default_config_args)
         terminate_event = Mock()
@@ -329,12 +310,12 @@ class TestDestinationThread(TestBase):
                                                dest=manager,
                                                interval=interval,
                                                terminate_event=terminate_event,
-                                               oneshot=True, options=self.options)
+                                               oneshot=False, options=self.options)
         # In this test we want to see that the wait method is called when we
         # expect and with what parameters we expect
         destination_thread.wait = Mock()
         destination_thread.is_terminated = Mock(return_value=False)
-        destination_thread._send_data(data_to_send)
+        destination_thread.check_report_status(batch_report1)
         # There should be three waits, one after the job is submitted with duration of
         # MinimumJobPollingInterval. The second and third with duration MinimumJobPollInterval * 2
         # (and all subsequent calls as demonstrated by the third wait)
@@ -342,6 +323,24 @@ class TestDestinationThread(TestBase):
             call(wait_time=MinimumJobPollInterval),
             call(wait_time=MinimumJobPollInterval * 2),
             call(wait_time=MinimumJobPollInterval * 2)])
+
+
+    # A closure to allow us to have a function that "modifies" the given
+    # report in a predictable way.
+    # In this case I want to set the state of the report to STATE_FINISHED
+    # after the first try
+
+    def check_report_state_closure(self, items):
+        item_iterator = iter(items)
+
+        def mock_check_report_state(report):
+            item = next(item_iterator)
+            if isinstance(item, Exception):
+                raise item
+            report.state = item
+            return report
+
+        return mock_check_report_state
 
     def test_send_data_poll_async_429(self):
         # This test's that when a 429 is detected during async polling
@@ -368,28 +367,9 @@ class TestDestinationThread(TestBase):
         error_to_throw = ManagerThrottleError(retry_after=62)
 
         manager = Mock()
-        manager.hypervisorCheckIn.return_value = report1
-        # A closure to allow us to have a function that "modifies" the given
-        # report in a predictable way.
-        # In this case I want to set the state of the report to STATE_FINISHED
-        # after the first try
+        manager.hypervisorCheckIn = Mock(side_effect=[error_to_throw, report1])
+        expected_wait_calls = [call(wait_time=error_to_throw.retry_after)]
 
-        def check_report_state_closure(items):
-            item_iterator = iter(items)
-
-            def mock_check_report_state(report):
-                item = next(item_iterator)
-                if isinstance(item, Exception):
-                    raise item
-                report.state = item
-                return report
-            return mock_check_report_state
-        states = [error_to_throw, AbstractVirtReport.STATE_FINISHED]
-        expected_wait_calls = [call(wait_time=MinimumJobPollInterval),
-                               call(wait_time=error_to_throw.retry_after)]
-
-        check_report_mock = check_report_state_closure(states)
-        manager.check_report_state = Mock(side_effect=check_report_mock)
         logger = Mock()
         terminate_event = Mock()
         interval = 10  # Arbitrary for this test

--- a/virtwho/virt/virt.py
+++ b/virtwho/virt/virt.py
@@ -1,5 +1,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import print_function
+
+from rhsm.connection import RestlibException
+
 """
 Module for abstraction of all virtualization backends, part of virt-who
 
@@ -478,6 +481,7 @@ class DestinationThread(IntervalThread):
         self.is_initial_run = True
         self.source_keys = source_keys
         self.last_report_for_source = {}  # Source_key to hash of last report
+        self.submitted_report_and_hash_for_source = {}  # Source key to submitted batch report and hash
         self.options = options
         self.reports_to_print = []  # A list of reports we would send but are
         #  going to print instead, to be used by the owner of the thread
@@ -505,13 +509,30 @@ class DestinationThread(IntervalThread):
         reports = {}
         for source_key in source_keys:
             report = self.source.get(source_key, NotSetSentinel)
-
             if report is None or report is NotSetSentinel:
                 if log_missing_reports:
                     self.logger.debug("No report available for source: %s" %
                                       source_key)
                 continue
-            if ignore_duplicates and report.hash == self.last_report_for_source.get(source_key,
+            if source_key in self.submitted_report_and_hash_for_source:
+                submitted_report = self.submitted_report_and_hash_for_source[source_key][0]
+                submitted_hash = self.submitted_report_and_hash_for_source[source_key][1]
+                self.check_report_status(submitted_report)
+                self.submitted_report_and_hash_for_source.pop(source_key)
+                if submitted_report.state == AbstractVirtReport.STATE_FINISHED:
+                    self.last_report_for_source[source_key] = submitted_hash
+                    if ignore_duplicates and report.hash == submitted_hash:
+                        self.logger.debug('Duplicate report found for config "%s", ignoring',
+                                          report.config.name)
+                        continue
+                elif submitted_report.state == AbstractVirtReport.STATE_PROCESSING:
+                    # cancel the task so we can send a new one
+                    # if that fails, it means that the state is not cancellable or we don't have this permission.
+                    try:
+                        self.dest.cancel_job(submitted_report)
+                    except Exception as e:
+                        self.logger.warning('The job for source %s cannot be cancelled: %s' , source_key, e.message)
+            elif ignore_duplicates and report.hash == self.last_report_for_source.get(source_key,
                                                                                     None):
                 self.logger.debug('Duplicate report found for config "%s", ignoring',
                                   report.config.name)
@@ -649,54 +670,10 @@ class DestinationThread(IntervalThread):
                 self.wait(wait_time=self.interval_modifier)
                 self.interval_modifier = 0
 
-            num_429_received = 0
-            first_attempt = True
-            # Poll for async results if async (retrying where necessary)
-            while result and batch_host_guest_report.state not in [
-                AbstractVirtReport.STATE_CANCELED,
-                AbstractVirtReport.STATE_FAILED,
-                AbstractVirtReport.STATE_FINISHED] and not self.is_terminated():
-                if self.interval_modifier != 0:
-                    wait_time = self.interval_modifier
-                    self.interval_modifier = 0
-                elif not first_attempt:
-                    wait_time = MinimumJobPollInterval * 2
-                else:
-                    wait_time = MinimumJobPollInterval
-
-                self.wait(wait_time=wait_time)
-
-                try:
-                    self.dest.check_report_state(batch_host_guest_report)
-                except ManagerThrottleError as e:
-                    if self._oneshot:
-                        self.logger.debug('429 encountered when checking job state in '
-                                          'oneshot mode, not retrying')
-                        sources_sent.extend(reports_batched)
-                        break
-                    retry_after = self.handle_429(e.retry_after, num_429_received)
-                    self.logger.debug('429 encountered while checking job '
-                                      'state, checking again in "%s"', retry_after)
-                    self.interval_modifier = retry_after
-                except (ManagerError, ManagerFatalError):
-                    self.logger.exception("Error during job check: ")
-                    if self._oneshot:
-                        sources_sent.extend(reports_batched)
-                    break
-                # If we get here and have to try again, it's not our first rodeo...
-                first_attempt = False
-
-            # If the batch report did not reach the finished state
-            # we do not want to update which report we last sent (as we
-            # might want to try to send the same report again next time)
-            if batch_host_guest_report.state == \
-                    AbstractVirtReport.STATE_FINISHED:
-                # Update the hash of the info last sent for each source
-                # included in the successful report
+            if result:
                 for source_key in reports_batched:
-                    self.last_report_for_source[source_key] = data_to_send[
-                        source_key].hash
-                    sources_sent.append(source_key)
+                    self.submitted_report_and_hash_for_source[source_key] =\
+                        (batch_host_guest_report, data_to_send[source_key].hash)
 
         # Send each Domain Guest List Report if necessary
         for source_key in domain_list_reports:
@@ -752,6 +729,37 @@ class DestinationThread(IntervalThread):
                                 if source_key not in sources_sent]
         return
 
+    def check_report_status(self, report):
+        self.logger.debug("Existing report state: %s" % report.state)
+        num_429_received = 0
+        first_attempt = True
+        while not report.state or report.state == AbstractVirtReport.STATE_CREATED:
+            if self.interval_modifier != 0:
+                wait_time = self.interval_modifier
+                self.interval_modifier = 0
+            elif not first_attempt:
+                wait_time = MinimumJobPollInterval * 2
+            else:
+                wait_time = MinimumJobPollInterval
+
+            self.wait(wait_time=wait_time)
+
+            try:
+                self.dest.check_report_state(report)
+            except ManagerThrottleError as e:
+                if self._oneshot:
+                    self.logger.debug('429 encountered when checking job state in '
+                                      'oneshot mode, not retrying')
+                    break
+                retry_after = self.handle_429(e.retry_after, num_429_received)
+                self.logger.debug('429 encountered while checking job '
+                                  'state, checking again in "%s"', retry_after)
+                self.interval_modifier = retry_after
+            except (ManagerError, ManagerFatalError):
+                self.logger.exception("Error during job check: ")
+                break
+            # If we get here and have to try again, it's not our first rodeo...
+            first_attempt = False
 
 class Satellite5DestinationThread(DestinationThread):
 


### PR DESCRIPTION
The timing has been changed so that the status is not checked directly
 after the submission. The current method was resulting in multiple
 status check retries while the checkin was being processed.

This version will check immediately before the next run. If the previous
 job has not yet been processed, it will be cancelled and treated as a
 failure. All other behavior for sending reports will remain constant.