### PR TITLE
ENT-554 Host reports for libvirt and rhevm include the system hardware uuid

### DIFF
--- a/tests/test_libvirtd.py
+++ b/tests/test_libvirtd.py
@@ -143,6 +143,18 @@ class TestLibvirtd(TestBase):
             self.assertTrue(host.name is not None)
 
     @patch('libvirt.openReadOnly')
+    def test_mapping_hypervisor_has_system_uuid(self, virt):
+        config = self.create_config('test', None, type='libvirt', server='abc://server/test')
+        datastore = Datastore()
+        virt.return_value.getCapabilities.return_value = LIBVIRT_CAPABILITIES_XML
+        virt.return_value.getType.return_value = "LIBVIRT_TYPE"
+        virt.return_value.getVersion.return_value = "VERSION 1337"
+        self.run_virt(config, datastore)
+        result = datastore.get(config.name)
+        for host in result.association['hypervisors']:
+            self.assertEqual(host.facts['dmi.system.uuid'], 'this-is-uuid')
+
+    @patch('libvirt.openReadOnly')
     def test_mapping_has_no_hostname_when_unavailible(self, virt):
         config = self.create_config('test', None, type='libvirt', server='abc://server/test')
         datastore = Datastore()

--- a/tests/test_rhevm.py
+++ b/tests/test_rhevm.py
@@ -60,6 +60,9 @@ HOSTS_XML = '''<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
             <topology sockets="1" cores="6" threads="2"/>
         </cpu>
         <version full_version="1.2.3" />
+        <hardware_information>
+            <uuid>db5a7a9f-6e33-3bfd-8129-c8010e4e1497</uuid>
+        </hardware_information>
     </host>
 </hosts>
 '''.format(**uuids)
@@ -183,6 +186,7 @@ class TestRhevM(TestBase):
                 Hypervisor.HYPERVISOR_TYPE_FACT: 'qemu',
                 Hypervisor.HYPERVISOR_VERSION_FACT: '1.2.3',
                 Hypervisor.HYPERVISOR_CLUSTER: 'Cetus',
+                Hypervisor.SYSTEM_UUID_FACT: 'db5a7a9f-6e33-3bfd-8129-c8010e4e1497',
             }
         )
         result = self.rhevm.getHostGuestMapping()['hypervisors'][0]
@@ -228,6 +232,7 @@ class TestRhevM(TestBase):
                 Hypervisor.HYPERVISOR_TYPE_FACT: 'qemu',
                 Hypervisor.HYPERVISOR_VERSION_FACT: '1.2.3',
                 Hypervisor.HYPERVISOR_CLUSTER: 'Cetus',
+                Hypervisor.SYSTEM_UUID_FACT: 'db5a7a9f-6e33-3bfd-8129-c8010e4e1497',
             }
         )
         result = self.rhevm.getHostGuestMapping()['hypervisors'][0]

--- a/virtwho/virt/libvirtd/libvirtd.py
+++ b/virtwho/virt/libvirtd/libvirtd.py
@@ -430,6 +430,7 @@ class Libvirtd(Virt):
             Hypervisor.CPU_SOCKET_FACT: self._remote_host_sockets(),
             Hypervisor.HYPERVISOR_TYPE_FACT: self.virt.getType(),
             Hypervisor.HYPERVISOR_VERSION_FACT: self.virt.getVersion(),
+            Hypervisor.SYSTEM_UUID_FACT: self.host_capabilities_xml.find('host/uuid').text,
         }
         host = Hypervisor(hypervisorId=self._remote_host_id(),
                           guestIds=self._listDomains(),

--- a/virtwho/virt/virt.py
+++ b/virtwho/virt/virt.py
@@ -105,6 +105,7 @@ class Hypervisor(object):
     HYPERVISOR_TYPE_FACT = 'hypervisor.type'
     HYPERVISOR_VERSION_FACT = 'hypervisor.version'
     HYPERVISOR_CLUSTER = 'hypervisor.cluster'
+    SYSTEM_UUID_FACT = 'dmi.system.uuid'
 
     def __init__(self, hypervisorId, guestIds=None, name=None, facts=None):
         """


### PR DESCRIPTION
The fact is added for scenarios where there can be a regular consumer check in
 and hypervisor reporting on the same host system.

Related BZ's: 1314902, 1410601, 1566000, 1576110