### PR TITLE
1368341: Warn that --sam/--satellite6 are unused & deprecated ENT-251

### DIFF
--- a/virt-who.8
+++ b/virt-who.8
@@ -50,13 +50,13 @@ Choose virtualization backend that should be used to gather host/guest associati
 Choose where the host/guest associations should be reported
 .TP
 \fB\-\-sam\fR
-[Deprecated] Report host/guest associations to the Subscription Asset Manager or Satellite 6 [default]
+[Deprecated] Report host/guest associations to the Subscription Asset Manager, Satellite 6, or Red Hat Subscription Management (RHSM). This option specifies the default behaviour, and thus it is not used [default]
 .TP
 \fB\-\-satellite5\fR
 [Deprecated] Report host/guest associations to the Satellite 5 server
-.IP
+.TP
 \fB\-\-satellite6\fR
-[Deprecated] Report host/guest associations to the Satellite 6 server
+[Deprecated] Report host/guest associations to the Subscription Asset Manager, Satellite 6, or Red Hat Subscription Management (RHSM). This option specifies the default behaviour, and thus it is not used [default]
 .IP
 .SS Libvirt options
 .IP
@@ -261,14 +261,14 @@ virt-who can report host/guest associations to Subscription Asset Manager (SAM),
 
 # virt-who --sam
 
-System must be registered using subscription-manager prior to using virt-who. Configuration for connecting to SAM is shared between subscription-manager and virt-who. This is default.
+System must be registered using subscription-manager prior to using virt-who. Configuration for connecting to SAM, or Satellite6, or Red Hat Subscription Management (RHSM) is shared between subscription-manager and virt-who. This option specifies the default behaviour, and thus it is not used.
 
 .TP
 2. Satellite 6
 
 # virt-who --satellite6
 
-System must be registered using subscription-manager prior to using virt-who. Configuration for connecting to Satellite 6 is shared between subscription-manager and virt-who.
+System must be registered using subscription-manager prior to using virt-who. Configuration for connecting to SAM, or Satellite6, or Red Hat Subscription Management (RHSM) is shared between subscription-manager and virt-who. This option specifies the default behaviour, and thus it is not used.
 
 .TP
 2. Satellite 5

--- a/virtwho/parser.py
+++ b/virtwho/parser.py
@@ -23,6 +23,7 @@ configuration from environment variables.
 """
 
 import os
+import sys as _sys
 from argparse import ArgumentParser, Action
 
 from virtwho import log, MinimumSendInterval, DefaultInterval, SAT5, SAT6
@@ -359,9 +360,13 @@ def parse_cli_arguments():
         description="Choose where the host/guest associations should be reported"
     )
     manager_group.add_argument("--sam", action="store_const", dest="sm_type", const=SAT6, default=SAT6,
-                               help="[Deprecated] Report host/guest associations to the Subscription Asset Manager [default]")
+                               help="[Deprecated] Report host/guest associations to the Subscription Asset Manager, "
+                               "Satellite 6, or Red Hat Subscription Management (RHSM). "
+                               "This option specifies the default behaviour, and thus it is not used [default]")
     manager_group.add_argument("--satellite6", action="store_const", dest="sm_type", const=SAT6,
-                               help="[Deprecated] Report host/guest associations to the Satellite 6 server")
+                               help="[Deprecated] Report host/guest associations to the Subscription Asset Manager, "
+                               "Satellite 6, or Red Hat Subscription Management (RHSM)."
+                               "This option specifies the default behaviour, and thus it is not used [default]")
     manager_group.add_argument("--satellite5", action="store_const", dest="sm_type", const=SAT5,
                                help="[Deprecated] Report host/guest associations to the Satellite 5 server")
     manager_group.add_argument("--satellite", action="store_const", dest="sm_type", const=SAT5)
@@ -521,6 +526,15 @@ def parse_options():
             elif option in SAT_OPTION_MAP:
                 display_option = SAT_OPTION_MAP[option]
             used_deprecated_cli_options.append(display_option)
+
+    # These two flags set the value of sm_type to the default value ('sam'), so ArgumentParser will not
+    # include them in the cli_options list, thus we have to manually check for and add them to
+    # the deprecated list for them to be included in the warning:
+    if '--satellite6' in _sys.argv:
+        used_deprecated_cli_options.append('satellite6')
+    if '--sam' in _sys.argv:
+        used_deprecated_cli_options.append('sam')
+
     deprecated_options_msg = "The following cli options: %s are deprecated and will be removed " \
     "in the next release. Please see 'man virt-who-config' for details on adding a configuration "\
     "section."


### PR DESCRIPTION
* Now logging a warning when --sam/--satellite6 are used.
* man page and --help output updated to explaing that these options are unused and virt-who will report to either sam/satellite/stage candlepin regardless of their being there.