### PR TITLE
Fixed hyperv wmi query. Invalid response (500)

### DIFF
--- a/virtwho/virt/hyperv/hyperv.py
+++ b/virtwho/virt/hyperv/hyperv.py
@@ -542,7 +542,7 @@ class HyperV(virt.Virt):
         https://social.technet.microsoft.com/Forums/windowsserver/en-US/dce2a4ec-10de-4eba-a19d-ae5213a2382d/how-to-tell-version-of-hyperv-installed?forum=winserverhyperv
         """
         vmmsVersion = ""
-        data = hypervsoap.Enumerate("select * from CIM_Datafile where FileName='vmms'", "root/cimv2")
+        data = hypervsoap.Enumerate("select * from CIM_Datafile where Path = '\\\\windows\\\\system32\\\\' and FileName='vmms'", "root/cimv2")
         for instance in hypervsoap.Pull(data, "root/cimv2"):
             if instance['Path'] == '\\windows\\system32\\':
                 vmmsVersion = instance['Version']


### PR DESCRIPTION
The function getVmmsVersion ran a wmi query searching for the file "vmms" on the entire system. This can cause high disk usage and timeout failures. Changing the query to limit the path to windows\system32 solves these issues and speeds up the query significantly. 

Errors thrown:
2018-06-20 10:38:46,467 [virtwho.main DEBUG] MainProcess(2955):Thread-2 @hyperv.py:post:399 - Invalid response (500) from Hyper-V: <s:Envelope xml:lang="en-US" xmlns:s="http://www.w3.org/2003/05/soap-envelope" xmlns:a="http://schemas.xmlsoap.org/ws/2004/08/addressing" xmlns:x="http://schemas.xmlsoap.org/ws/2004/09/transfer" xmlns:e="http://schemas.xmlsoap.org/ws/2004/08/eventing" xmlns:n="http://schemas.xmlsoap.org/ws/2004/09/enumeration" xmlns:w="http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd" xmlns:p="http://schemas.microsoft.com/wbem/wsman/1/wsman.xsd"><s:Header><a:Action>http://schemas.dmtf.org/wbem/wsman/1/wsman/fault</a:Action><a:MessageID>uuid:34466961-FB07-4ED1-BE41-8D80D815A248</a:MessageID><a:To>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</a:To><a:RelatesTo>uuid:a35f73ca-7497-11e8-8978-00155d25cb22</a:RelatesTo></s:Header><s:Body><s:Fault><s:Code><s:Value>s:Receiver</s:Value><s:Subcode><s:Value>w:InternalError</s:Value></s:Subcode></s:Code><s:Reason><s:Text xml:lang="">An internal error occurred. </s:Text></s:Reason><s:Detail><f:WSManFault xmlns:f="http://schemas.microsoft.com/wbem/wsman/1/wsmanfault" Code="1359" Machine="lmconl-na-vh5.lmc.onl"><f:Message><f:ProviderFault provider="WMI Provider" path="C:\Windows\system32\WsmWmiPl.dll"><f:WSManFault xmlns:f="http://schemas.microsoft.com/wbem/wsman/1/wsmanfault" Code="1359" Machine="LMCONL-NA-VH5.lmc.onl"><f:Message>HRESULT = 0x80041032</f:Message></f:WSManFault></f:ProviderFault></f:Message></f:WSManFault></s:Detail></s:Fault></s:Body></s:Envelope>