### PR TITLE
Update for build process

### DIFF
--- a/rel-eng/releasers.conf
+++ b/rel-eng/releasers.conf
@@ -32,7 +32,7 @@ branches = rhel-7.6
 required_bz_flags = rhel-7.6.0+
 # Change this if you wish to use a placeholder "rebase" bug if none
 # are found in the changelog.
-#placeholder_bz = 1589896
+placeholder_bz = 1589896
 
 #[copr-dgoodwin]
 #releaser = tito.release.CoprReleaser

--- a/rel-eng/tito.props
+++ b/rel-eng/tito.props
@@ -1,5 +1,5 @@
 [buildconfig]
-builder = tito.builder.Builder
+builder = tito.distributionbuilder.DistributionBuilder
 tagger = tito.tagger.VersionTagger
 changelog_do_not_remove_cherrypick = 0
 changelog_format = %s (%ae)


### PR DESCRIPTION
Needs Distirubution Buildler so that the tar ball is created correctly for the RPM tool.
Uncomment on the placeholder bug in 7.6
