### PR TITLE
kubevirt: rename virtual machine instance

### DIFF
--- a/tests/test_kubevirt.py
+++ b/tests/test_kubevirt.py
@@ -89,7 +89,7 @@ class TestKubevirt(TestBase):
         kube_api.list_node.return_value = self.nodes()
 
         kubevirt_api = Mock()
-        kubevirt_api.list_virtual_machine_for_all_namespaces_0.return_value = self.vms()
+        kubevirt_api.list_virtual_machine_instance_for_all_namespaces.return_value = self.vms()
 
         self.kubevirt.kube_api = kube_api
         self.kubevirt.kubevirt_api = kubevirt_api

--- a/virtwho/virt/kubevirt/kubevirt.py
+++ b/virtwho/virt/kubevirt/kubevirt.py
@@ -53,10 +53,10 @@ class Kubevirt(virt.Virt):
         return os.environ['KUBECONFIG']
 
     def prepare(self):
-        self.kubevirt_api = self.kuebvirt()
+        self.kubevirt_api = self.virt()
         self.kube_api = self.kube()
 
-    def kuebvirt(self):
+    def virt(self):
         from kubernetes import config
         import kubevirt
 
@@ -74,7 +74,7 @@ class Kubevirt(virt.Virt):
         return self.kube_api.list_node()
 
     def get_vms(self):
-        return self.kubevirt_api.list_virtual_machine_for_all_namespaces_0()
+        return self.kubevirt_api.list_virtual_machine_instance_for_all_namespaces()
     
     def getHostGuestMapping(self):
         """


### PR DESCRIPTION
In kubevirt 0.7.0 there was a rename of virtual machine to virtual
machine instance. This PR align kubevirt api change with virt-who.