### PR TITLE
1510920: Change the choreography for the job status check

### DIFF
--- a/virtwho/manager/subscriptionmanager/subscriptionmanager.py
+++ b/virtwho/manager/subscriptionmanager/subscriptionmanager.py
@@ -280,7 +280,7 @@ class SubscriptionManager(Manager):
             raise ManagerError("Communication with subscription manager failed: %s" % str(e))
 
         if is_async is True:
-            report.state = AbstractVirtReport.STATE_PROCESSING
+            report.state = AbstractVirtReport.STATE_CREATED
             report.job_id = result['id']
         else:
             report.state = AbstractVirtReport.STATE_FINISHED


### PR DESCRIPTION
The order has been changed so that the status is not checked directly
 after the submission. The current method was resulting in multiple
 status check retries while the checkin was being processed.

This version will check immediately before the next run. If the previous
 job has not yet been processed, it will be bypassed until the next interval

One shot reports will no longer wait for the status to be returned.