### PR TITLE
1581021: Decode error from unicode passwords

### DIFF
--- a/tests/test_hyperv.py
+++ b/tests/test_hyperv.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 from __future__ import print_function
 """
 Test of Hyper-V virtualization backend.
@@ -141,7 +143,7 @@ class TestHyperV(TestBase):
             'type': 'hyperv',
             'server': 'localhost',
             'username': 'username',
-            'password': 'password',
+            'password': u'1€345678',
             'owner': 'owner',
             'env': 'env,'
         }

--- a/virtwho/virt/esx/esx.py
+++ b/virtwho/virt/esx/esx.py
@@ -119,11 +119,9 @@ class Esx(virt.Virt):
                                   terminate_event=terminate_event,
                                   interval=interval,
                                   oneshot=oneshot)
-        self.url = config['server']
-        self.username = config['username']
-        self.password = config['password']
-
-        self.config = config
+        self.url = self.config['server']
+        self.username = self.config['username']
+        self.password = self.config['password']
 
         self.filter = None
         self.sc = None

--- a/virtwho/virt/hyperv/hyperv.py
+++ b/virtwho/virt/hyperv/hyperv.py
@@ -32,6 +32,7 @@ import requests
 from virtwho import virt
 from . import ntlm
 from virtwho.config import VirtConfigSection
+import six
 
 try:
     from uuid import uuid1
@@ -507,9 +508,9 @@ class HyperV(virt.Virt):
                                      terminate_event=terminate_event,
                                      interval=interval,
                                      oneshot=oneshot)
-        self.url = config['url']
-        self.username = config['username']
-        self.password = config['password']
+        self.url = self.config['url']
+        self.username = self.config['username']
+        self.password = self.config['password']
 
         # First try to use old API (root/virtualization namespace) if doesn't
         # work, go with root/virtualization/v2
@@ -624,3 +625,18 @@ class HyperV(virt.Virt):
 
     def ping(self):
         return True
+
+    @staticmethod
+    def _to_unicode(value):
+        try:
+            return six.text_type(value, 'utf-8')
+        except TypeError:
+            return value
+
+    @property
+    def password(self):
+        return self._password
+
+    @password.setter
+    def password(self, value):
+        self._password = self._to_unicode(value)


### PR DESCRIPTION
Added handling for unicode passwords

Related 158022: Unicode is read from rhevm config file but not allowed in
python version < 3. Python BasicAuth excludes it.