### PR TITLE
1577954: Added config option filter_type; ENT-580

### DIFF
--- a/tests/test_config_section_virt.py
+++ b/tests/test_config_section_virt.py
@@ -42,7 +42,8 @@ LIBVIRT_SECTION_VALUES = {
     'env': '123456',
     'owner': '123456',
     'hypervisor_id': 'uuid',
-    'filter_hosts': '*.example.com'
+    'filter_hosts': '*.example.com',
+    'filter_type': 'wildcards'
 }
 
 
@@ -273,6 +274,33 @@ class TestVirtConfigSection(TestBase):
         """
         self.init_virt_config_section()
         result = self.virt_config._validate_filter('filter_hosts')
+        self.assertIsNone(result)
+
+    def test_validate_missing_filter_type(self):
+        """
+        Test validation of missing filter type
+        """
+        self.init_virt_config_section()
+        del self.virt_config['filter_type']
+        result = self.virt_config._validate_filter('filter_hosts')
+        self.assertIsNotNone(result)
+
+    def test_validate_wrong_filter_type(self):
+        """
+        Test validation of wrong filter type
+        """
+        self.init_virt_config_section()
+        self.virt_config['filter_type'] = 'not_supported_filter_type'
+        result = self.virt_config._validate_filter_type('filter_type')
+        self.assertIsNotNone(result)
+
+    def test_validate_regex_filter_type(self):
+        """
+        Test validation of regex filter type
+        """
+        self.init_virt_config_section()
+        self.virt_config['filter_type'] = 'regex'
+        result = self.virt_config._validate_filter_type('filter_type')
         self.assertIsNone(result)
 
     def test_validate_filter_hypervisor_id_hostname(self):

--- a/tests/test_virt.py
+++ b/tests/test_virt.py
@@ -33,6 +33,11 @@ class TestVirtInclude(TestBase):
         self.filter_hosts('filter_hosts=12?45')
         self.filter_hosts('filter_hosts=12[36]45')
 
+    def test_filter_hosts_glob_filter_type(self):
+        self.filter_hosts('filter_hosts=12*', 'filter_type=wildcards')
+        self.filter_hosts('filter_hosts=12?45', 'filter_type=wildcards')
+        self.filter_hosts('filter_hosts=12[36]45', 'filter_type=wildcards')
+
     def test_exclude_hosts_glob(self):
         self.filter_hosts('exclude_hosts=00*')
         self.filter_hosts('exclude_hosts=00?00')
@@ -42,6 +47,11 @@ class TestVirtInclude(TestBase):
         self.filter_hosts('filter_hosts=12.*')
         self.filter_hosts('filter_hosts=12.+45')
         self.filter_hosts('filter_hosts=12[36]45')
+
+    def test_filter_hosts_regex_filter_type(self):
+        self.filter_hosts('filter_hosts=12.*', 'filter_type=regex')
+        self.filter_hosts('filter_hosts=12.+45', 'filter_type=regex')
+        self.filter_hosts('filter_hosts=12[36]45', 'filter_type=regex')
 
     def test_exclude_hosts_regex(self):
         self.filter_hosts('exclude_hosts=00.*')
@@ -54,7 +64,7 @@ class TestVirtInclude(TestBase):
     def test_exclude_host_uuids(self):
         self.filter_hosts('exclude_host_uuids=00000')
 
-    def filter_hosts(self, config):
+    def filter_hosts(self, filter_something, filter_type=''):
         config_dir = tempfile.mkdtemp()
         self.addCleanup(shutil.rmtree, config_dir)
         with open(os.path.join(config_dir, "test.conf"), "w") as f:
@@ -66,8 +76,9 @@ username=username
 password=password
 owner=owner
 env=env
-{config}
-""".format(config=config))
+{filter_something}
+{filter_type}
+""".format(filter_something=filter_something, filter_type=filter_type))
         conf = parse_file(os.path.join(config_dir, "test.conf"))
         test_conf_values = conf.pop('test')
         effective_config = EffectiveConfig()

--- a/tests/test_xen.py
+++ b/tests/test_xen.py
@@ -115,6 +115,7 @@ class TestXenConfigSection(TestBase):
         self.init_virt_config_section()
         # Supported filter
         self.xen_config['filter_hosts'] = '*.company.com, *.company.net'
+        self.xen_config['filter_type'] = 'wildcards'
         # Unsupported filters
         self.xen_config['filter_host_parents'] = 'host_parents'
         self.xen_config['exclude_host_parents'] = 'host_parents'

--- a/virt-who-config.5
+++ b/virt-who-config.5
@@ -129,6 +129,9 @@ Only hosts which uuid (or hostname or hwuuid, based on \fBhypervisor_id\fR) is s
 \fBexclude_hosts\fR
 Hosts which uuid (or hostname or hwuuid, based on \fBhypervisor_id\fR) is specified in comma-separated list in this option will \fBNOT\fR be reported.  Wildcards and regular expressions are supported.  Put the value into the double-quotes if it contains special characters (like comma). \fBexclude_host_uuids\fR is deprecated alias for this option.
 .TP
+\fBfilter_type\fR
+When this propery is not set, then virt-who tries to detect wildcards or regular expression in value of filter_hosts or exclude_hosts. This option allows to specify usage of regular expression (value 'regex') or wildcards (value 'wildcards').
+.TP
 \fBhypervisor_id\fR
 Property that should be used as identification of the hypervisor. Can be one of following: \fBuuid\fR, \fBhostname\fR, \fBhwuuid\fR. Note that some virtualization backends don't have all of them implemented. Default is \fBuuid\fR. \fBhwuuid\fR is applicable to esx and rhevm only. This property is meant to be set up before initial run of virt-who. Changing it later will result in duplicated entries in the subscription manager.
 

--- a/virtwho/virt/virt.py
+++ b/virtwho/virt/virt.py
@@ -243,21 +243,38 @@ class HostGuestAssociationReport(AbstractVirtReport):
                 pass
         self.exclude_hosts = exclude_hosts
         self.filter_hosts = filter_hosts
+        try:
+            self.filter_type = self._config['filter_type']
+        except KeyError:
+            # FIXME: default value should be there
+            self.filter_type = None
 
     def __repr__(self):
         return 'HostGuestAssociationReport({0.config!r}, {0._assoc!r}, {0.state!r})'.format(self)
 
     def _filter(self, host, filterlist):
         for i in filterlist:
-            if fnmatch.fnmatch(host.lower(), i.lower()):
-                # match is found
-                return True
-            try:
-                if re.match("^" + i + "$", host, re.IGNORECASE):
+            if self.filter_type is None:
+                if fnmatch.fnmatch(host.lower(), i.lower()):
                     # match is found
                     return True
-            except:
-                pass
+                try:
+                    if re.match("^" + i + "$", host, re.IGNORECASE):
+                        # match is found
+                        return True
+                except:
+                    pass
+            elif self.filter_type == "wildcards":
+                if fnmatch.fnmatch(host.lower(), i.lower()):
+                    # match is found
+                    return True
+            elif self.filter_type == "regex":
+                try:
+                    if re.match("^" + i + "$", host, re.IGNORECASE):
+                        # match is found
+                        return True
+                except:
+                    pass
         # no match
         return False
 


### PR DESCRIPTION
* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1577954
* Added new config file option filter_type. Value of this option
  can be one of: 'wildcards, 'regex'.
* When filtering is used and filter_type is not specified, then
  warning is printed to log file. Behavior should be the same.