### PR TITLE
1387800: set name of ESX cluster properly

### DIFF
--- a/tests/complex/data/esx/esx_waitforupdatesexresponse_0.xml
+++ b/tests/complex/data/esx/esx_waitforupdatesexresponse_0.xml
@@ -203,6 +203,15 @@
                             <val xsi:type="ArrayOfManagedObjectReference"></val>
                         </changeSet>
                     </objectSet>
+                    <objectSet>
+                        <kind>enter</kind>
+                        <obj type="ClusterComputeResource">ha-compute-res</obj>
+                        <changeSet>
+                            <name>name</name>
+                            <op>assign</op>
+                            <val xsi:type="xsd:string">ha-cluster-1</val>
+                        </changeSet>
+                    </objectSet>
                 </filterSet>
             </returnval>
         </WaitForUpdatesExResponse>

--- a/tests/complex/data/esx/esx_waitforupdatesexresponse_1.xml
+++ b/tests/complex/data/esx/esx_waitforupdatesexresponse_1.xml
@@ -155,6 +155,15 @@
                             <val xsi:type="ArrayOfManagedObjectReference"></val>
                         </changeSet>
                     </objectSet>
+                    <objectSet>
+                        <kind>enter</kind>
+                        <obj type="ClusterComputeResource">ha-compute-res</obj>
+                        <changeSet>
+                            <name>name</name>
+                            <op>assign</op>
+                            <val xsi:type="xsd:string">ha-cluster-1</val>
+                        </changeSet>
+                    </objectSet>
                 </filterSet>
             </returnval>
         </WaitForUpdatesExResponse>

--- a/tests/complex/virtwhotest.py
+++ b/tests/complex/virtwhotest.py
@@ -235,7 +235,10 @@ class VirtBackendTestMixin(object):
         returned = json.loads(out)
         # Test facts
         for hypervisor in returned['hypervisors']:
-            self.assertTrue(hypervisor['facts']['hypervisor.cluster'].startswith('ha-compute-res'))
+            if hypervisor['facts']['hypervisor.type'] == 'vmware':
+                self.assertTrue(hypervisor['facts']['hypervisor.cluster'].startswith('ha-cluster-1'))
+            else:
+                self.assertTrue(hypervisor['facts']['hypervisor.cluster'].startswith('ha-compute-res'))
         # Transform it to the same format as assoc from SAM server
         assoc = dict((host['uuid'], host['guests']) for host in returned['hypervisors'])
         self.check_assoc(assoc, {

--- a/tests/test_esx.py
+++ b/tests/test_esx.py
@@ -118,7 +118,7 @@ class TestEsx(TestBase):
         expected_guest_state = Guest.STATE_RUNNING
 
         fake_parent = MagicMock()
-        fake_parent.value = 'Fake_parent'
+        fake_parent.value = 'fake_parent_id'
         fake_parent._type = 'ClusterComputeResource'
 
         fake_vm_id = MagicMock()
@@ -142,6 +142,9 @@ class TestEsx(TestBase):
         fake_hosts = {'random-host-id': fake_host}
         self.esx.hosts = fake_hosts
 
+        fake_cluster = {'name': 'Fake_cluster_name'}
+        self.esx.clusters = {'fake_parent_id': fake_cluster}
+
         expected_result = Hypervisor(
             hypervisorId=expected_hypervisorId,
             name=expected_hostname,
@@ -156,7 +159,7 @@ class TestEsx(TestBase):
                 Hypervisor.CPU_SOCKET_FACT: '1',
                 Hypervisor.HYPERVISOR_TYPE_FACT: 'vmware',
                 Hypervisor.HYPERVISOR_VERSION_FACT: '1.2.3',
-                Hypervisor.HYPERVISOR_CLUSTER: 'Fake_parent',
+                Hypervisor.HYPERVISOR_CLUSTER: 'Fake_cluster_name',
             }
         )
         result = self.esx.getHostGuestMapping()['hypervisors'][0]
@@ -170,7 +173,8 @@ class TestEsx(TestBase):
         expected_guest_state = Guest.STATE_UNKNOWN
 
         fake_parent = MagicMock()
-        fake_parent.value = 'Fake_parent'
+        fake_parent.value = 'fake_parent_id'
+        fake_parent._type = 'ClusterComputeResource'
 
         fake_vm_id = MagicMock()
         fake_vm_id.value = 'guest1'
@@ -192,6 +196,9 @@ class TestEsx(TestBase):
         fake_hosts = {'random-host-id': fake_host}
         self.esx.hosts = fake_hosts
 
+        fake_cluster = {'name': 'Fake_cluster_name'}
+        self.esx.clusters = {'fake_parent_id': fake_cluster}
+
         expected_result = Hypervisor(
             hypervisorId=expected_hypervisorId,
             name=expected_hostname,
@@ -206,6 +213,7 @@ class TestEsx(TestBase):
                 Hypervisor.CPU_SOCKET_FACT: '1',
                 Hypervisor.HYPERVISOR_TYPE_FACT: 'vmware',
                 Hypervisor.HYPERVISOR_VERSION_FACT: '1.2.3',
+                Hypervisor.HYPERVISOR_CLUSTER: 'Fake_cluster_name'
             }
         )
         result = self.esx.getHostGuestMapping()['hypervisors'][0]


### PR DESCRIPTION
* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1387800#c17
* It wasn't so obvious that name of cluster displayed in vSphere UI
  is something else than we can see as ID of cluster in XML.
* Fixed coresponding unit tests.