### PR TITLE
kubevirt: Ignore vmis in Scheduling

### DIFF
--- a/virtwho/virt/kubevirt/kubevirt.py
+++ b/virtwho/virt/kubevirt/kubevirt.py
@@ -106,6 +106,11 @@ class Kubevirt(virt.Virt):
         for vm in vms.items:
             metadata = vm.metadata
             host_name = vm.status.node_name
+
+            # a vm is not scheduled on any hosts
+            if host_name is None:
+                continue
+
             guest_id = metadata.namespace + '/' + metadata.name
             # a vm is always in running state
             status = virt.Guest.STATE_RUNNING


### PR DESCRIPTION
There is time when virtual machine instance is not assigned to specific
host but it appears in vmi list. Such vmis should be reported only when
scheduled on specific host.