### PR TITLE
Install subscription-manager, not python-rhsm which is deprecated:

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,12 @@ env:
 sudo: required
 dist: trusty
 install:
+  - pip install -U setuptools
   - pip install -r requirements.txt
   - pip install -U python-dateutil M2Crypto "libvirt-python<=4.0.0" unittest2 pytest-timeout mock
 script: py.test --timeout=30 -v
 before_install:
   - sudo apt-get update -qq
-  - sudo apt-get install -y libvirt0 swig libvirt-dev libssl-dev
+  - sudo apt-get install -y libvirt0 swig libvirt-dev libssl-dev intltool
   # Fix for missing sysconfig module in python2.6
   - sudo cp /usr/include/x86_64-linux-gnu/openssl/opensslconf.h /usr/include/openssl/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 suds-py3;python_version>="3.0"
 suds;python_version<"3.0"
-git+https://github.com/candlepin/python-rhsm#egg=rhsm
+git+https://github.com/candlepin/subscription-manager#egg=subscription_manager
 git+https://github.com/candlepin/python-iniparse#egg=iniparse;python_version>="3.0"
 iniparse;python_version<"3.0"
 requests>=2.0


### PR DESCRIPTION
- Removed python-rhsm from the requirements, and added subscription-manager as dependency.
- Added some dependencies that travis requires to install subscription-manager.