### PR TITLE
1637407: vCenter mapping info failure due to TypeError

### DIFF
--- a/virtwho/virt/esx/esx.py
+++ b/virtwho/virt/esx/esx.py
@@ -27,7 +27,7 @@ import suds.client
 import requests
 import errno
 import stat
-from six import StringIO
+from six import BytesIO
 import io
 import logging
 from time import time
@@ -88,7 +88,7 @@ class RequestsTransport(suds.transport.Transport):
     def open(self, request):
         resp = self._session.get(request.url, headers=request.headers, verify=False)
         resp.raise_for_status()
-        return StringIO(resp.content.decode('utf-8', 'ignore'))
+        return BytesIO(resp.content)
 
     def send(self, request):
         resp = self._session.post(


### PR DESCRIPTION
Failure occured when running aginst python 3.

To see the fix run, test_esx.py on python 3 in master then on this branch.  