### PR TITLE
1638250: Improved fix for http proxy issue

### DIFF
--- a/virtwho/config.py
+++ b/virtwho/config.py
@@ -1460,8 +1460,16 @@ def init_config(env_options, cli_options, config_dir=None):
                 effective_config[VW_ENV_CLI_SECTION_NAME][key.lower()] = value
 
     # 1638250: issue in the urllib or requests package in python 3
-    if 'http_proxy' in os.environ and 'https_proxy' not in os.environ:
-        os.environ['https_proxy'] = os.environ['http_proxy']
+    if six.PY3:
+        https = None
+        if 'https_proxy' in os.environ:
+            https = os.environ['https_proxy']
+        http = None
+        if 'http_proxy' in os.environ:
+            http =  os.environ['http_proxy']
+            del os.environ['http_proxy']
+        if http and not https:
+            os.environ['https_proxy'] = http
 
     # Now with the aggregate config data, run it through the appropriate class to get it validated/defaulted.
     effective_config[VW_ENV_CLI_SECTION_NAME] = VirtConfigSection.from_dict(effective_config[VW_ENV_CLI_SECTION_NAME], VW_ENV_CLI_SECTION_NAME, effective_config)


### PR DESCRIPTION
If http_proxy is specified it is moved to https_proxy unless there is already a value for https_proxy.
Virt-who does not yet use this for its communication with the hypervisor manager, and the value for http_proxy is causing an error.

To test this [use rhel 8]:
export https_proxy='https://10.73.3.248:3128' && export http_proxy='https://10.73.3.248:3129' && virt-who -do -c qe_hyperv_1638250.conf [use variations of the variable values]

qe_hyperv_1638250.conf:
[hyperv_1638250]
type=hyperv
owner=711497
env=Library
server=10.73.5.212
username=Administrator
password=Welcome1


