### PR TITLE
[kubevirt] Correct the config file logic

### DIFF
--- a/virtwho/virt/kubevirt/kubevirt.py
+++ b/virtwho/virt/kubevirt/kubevirt.py
@@ -42,7 +42,7 @@ class KubevirtConfigSection(VirtConfigSection):
         return: Return None or info/warning/error
         """
         path = self._values[key]
-        if os.path.isfile(path):
+        if not os.path.isfile(path):
             return [(
                     'warning',
                     "Kubeconfig file was not found at %s" % path


### PR DESCRIPTION
This fix corrects the logic of warning when the config file was not found