### PR TITLE
kubevirt: drop kubernetes and kubevirt dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ requests>=2.0
 m2crypto;python_version<"3.0"
 six
 cryptography
+PyYAML

--- a/tests/test_kubevirt.py
+++ b/tests/test_kubevirt.py
@@ -43,56 +43,45 @@ class TestKubevirt(TestBase):
             self.kubevirt = Virt.from_config(self.logger, config, Datastore())
 
     def nodes(self):
-        metadata = Mock()
-        metadata.name = "master"
+        node = {
+            'metadata': {
+                'name': 'master'
+            },
+            'status': {
+                'nodeInfo': {
+                    'machineID': '52c01ad890e84b15a1be4be18bd64ecd',
+                    'kubeletVersion': 'v1.9.1+a0ce1bc657'
+                },
+                'addresses': [
+                    {'address': 'master'}
+                ],
+                'allocatable' : {
+                    'cpu': '2'
+                }
+            }
+        }
 
-        node_info = Mock()
-        node_info.machine_id = "52c01ad890e84b15a1be4be18bd64ecd"
-        node_info.kubelet_version = "v1.9.1+a0ce1bc657"
-
-        address = Mock()
-        address.address = "master"
-
-        status = Mock()
-        status.node_info = node_info
-        status.addresses = [address]
-        status.allocatable = {"cpu": "2"}
-
-        node = Mock()
-        node.metadata = metadata
-        node.status = status
-
-        nodes = Mock()
-        nodes.items = [node]
-
-        return nodes
+        return {'items': [node]}
 
     def vms(self):
-        metadata = Mock()
-        metadata.name = "win-2016"
-        metadata.namespace = "default"
+        vm = {
+            'metadata': {
+                'name': 'win-2016',
+                'namespace': 'default',
+            },
+            'status': {
+                'nodeName': 'master',
+            }
+        }
 
-        status = Mock()
-        status.node_name = "master"
-
-        vm = Mock()
-        vm.metadata = metadata
-        vm.status = status
-
-        vms = Mock()
-        vms.items = [vm]
-
-        return vms
+        return {'items': [vm]}
 
     def test_getHostGuestMapping(self):
-        kube_api = Mock()
-        kube_api.list_node.return_value = self.nodes()
+        client = Mock()
+        client.get_nodes.return_value = self.nodes()
+        client.get_vms.return_value = self.vms()
 
-        kubevirt_api = Mock()
-        kubevirt_api.list_virtual_machine_instance_for_all_namespaces.return_value = self.vms()
-
-        self.kubevirt.kube_api = kube_api
-        self.kubevirt.kubevirt_api = kubevirt_api
+        self.kubevirt._client = client
 
         expected_result = Hypervisor(
             hypervisorId='52c01ad890e84b15a1be4be18bd64ecd',

--- a/virt-who.spec
+++ b/virt-who.spec
@@ -33,6 +33,7 @@ Source0:        %{name}-%{version}.tar.gz
 BuildArch:      noarch
 BuildRequires:  %{python_ver}-devel
 BuildRequires:  %{python_ver}-setuptools
+BuildRequires:  PyYAML
 # rhel 8 has different naming going forward
 %if (0%{?rhel} && 0%{?rhel} >= 8)
 Requires:      platform-python-setuptools
@@ -65,6 +66,7 @@ Requires:       %{python_ver}-six
 # python-argparse is required for Python 2.6 on EL6
 %{?el6:Requires: python-argparse}
 Requires:       openssl
+Requires:       PyYAML
 
 %if %{use_systemd}
 %if %{use_python3}

--- a/virtwho/virt/kubevirt/client.py
+++ b/virtwho/virt/kubevirt/client.py
@@ -1,0 +1,125 @@
+#
+# Copyright 2019 Red Hat, Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA
+#
+# Refer to the README and COPYING files for full details of the license
+#
+from __future__ import absolute_import
+
+import json
+import ssl
+import urllib3
+
+from six import PY3
+
+from virtwho.virt.kubevirt import config
+
+
+class KubeClient:
+
+    def __init__(self, path):
+        cfg = config.Configuration()
+        cl = config._get_kube_config_loader_for_yaml_file(path)
+        cl.load_and_set(cfg)
+
+        cert_reqs = ssl.CERT_REQUIRED
+        ca_certs = cfg.ssl_ca_cert
+        cert_file = cfg.cert_file
+        key_file = cfg.key_file
+
+        self._pool_manager = urllib3.PoolManager(
+            num_pools=4,
+            maxsize=4,
+            cert_reqs=cert_reqs,
+            ca_certs=ca_certs,
+            cert_file=cert_file,
+            key_file=key_file
+        )
+
+        self.host = cfg.host
+        self._version = self._kubevirt_version()
+
+    def get_nodes(self):
+        return self._request('/api/v1/nodes')
+
+    def get_vms(self):
+        return self._request('/apis/kubevirt.io/' + self._version + '/virtualmachineinstances')
+
+    def _kubevirt_version(self):
+        versions = self._request('/apis/kubevirt.io')
+        return versions['preferredVersion']['version']
+
+    def _request(self, path):
+        header_params = {}
+
+        header_params['Accept'] = 'application/json'
+        header_params['Content-Type'] = 'application/json'
+
+        url = self.host + path
+
+        try:
+            r = self._pool_manager.request("GET", url,
+                                          fields=None,
+                                          preload_content=True,
+                                          headers=header_params)
+        except urllib3.exceptions.SSLError as e:
+            msg = "{0}\n{1}".format(type(e).__name__, str(e))
+            raise ApiException(status=0, reason=msg)
+
+        # In the python 3, the response.data is bytes.
+        # we need to decode it to string.
+        if PY3:
+            r.data = r.data.decode('utf8')
+
+        if not 200 <= r.status <= 299:
+            raise ApiException(http_resp=r)
+
+        # fetch data from response object
+        try:
+            data = json.loads(r.data)
+        except ValueError:
+            data = r.data
+
+        return data
+
+
+class ApiException(Exception):
+
+    def __init__(self, status=None, reason=None, http_resp=None):
+        if http_resp:
+            self.status = http_resp.status
+            self.reason = http_resp.reason
+            self.body = http_resp.data
+            self.headers = http_resp.getheaders()
+        else:
+            self.status = status
+            self.reason = reason
+            self.body = None
+            self.headers = None
+
+    def __str__(self):
+        """
+        Custom error messages for exception
+        """
+        error_message = "({0})\n"\
+                        "Reason: {1}\n".format(self.status, self.reason)
+        if self.headers:
+            error_message += "HTTP response headers: {0}\n".format(self.headers)
+
+        if self.body:
+            error_message += "HTTP response body: {0}\n".format(self.body)
+
+        return error_message

--- a/virtwho/virt/kubevirt/config.py
+++ b/virtwho/virt/kubevirt/config.py
@@ -1,0 +1,254 @@
+#
+# Copyright 2019 Red Hat, Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA
+#
+# Refer to the README and COPYING files for full details of the license
+#
+from __future__ import absolute_import
+
+import atexit
+import base64
+import os
+import tempfile
+import yaml
+
+
+KUBE_CONFIG_DEFAULT_LOCATION = os.environ.get('KUBECONFIG', '~/.kube/config')
+_temp_files = {}
+
+
+def _create_temp_file_with_content(content):
+    if len(_temp_files) == 0:
+        atexit.register(_cleanup_temp_files)
+    # Because we may change context several times, try to remember files we
+    # created and reuse them at a small memory cost.
+    content_key = str(content)
+    if content_key in _temp_files:
+        return _temp_files[content_key]
+    _, name = tempfile.mkstemp()
+    _temp_files[content_key] = name
+    with open(name, 'wb') as fd:
+        fd.write(content.encode() if isinstance(content, str) else content)
+    return name
+
+
+def _cleanup_temp_files():
+    global _temp_files
+    for temp_file in _temp_files.values():
+        try:
+            os.remove(temp_file)
+        except OSError:
+            pass
+    _temp_files = {}
+
+
+def _get_kube_config_loader_for_yaml_file(filename, **kwargs):
+    with open(filename) as f:
+        return KubeConfigLoader(
+            config_dict=yaml.load(f),
+            config_base_path=os.path.abspath(os.path.dirname(filename)),
+            **kwargs)
+
+
+class Configuration(object):
+    pass
+
+
+class ConfigException(Exception):
+    pass
+
+
+class KubeConfigLoader(object):
+
+    def __init__(self, config_dict, active_context=None,
+                 config_base_path="",
+                 config_persister=None):
+        self._config = ConfigNode('kube-config', config_dict)
+        self._current_context = None
+        self._user = None
+        self._cluster = None
+        self.set_active_context(active_context)
+        self._config_base_path = config_base_path
+        self._config_persister = config_persister
+
+    def set_active_context(self, context_name=None):
+        if context_name is None:
+            context_name = self._config['current-context']
+        self._current_context = self._config['contexts'].get_with_name(
+            context_name)
+        if (self._current_context['context'].safe_get('user') and
+                self._config.safe_get('users')):
+            user = self._config['users'].get_with_name(
+                self._current_context['context']['user'], safe=True)
+            if user:
+                self._user = user['user']
+            else:
+                self._user = None
+        else:
+            self._user = None
+        self._cluster = self._config['clusters'].get_with_name(
+            self._current_context['context']['cluster'])['cluster']
+
+    def _load_cluster_info(self):
+        if 'server' in self._cluster:
+            self.host = self._cluster['server']
+            if self.host.startswith("https"):
+                self.ssl_ca_cert = FileOrData(
+                    self._cluster, 'certificate-authority',
+                    file_base_path=self._config_base_path).as_file()
+                self.cert_file = FileOrData(
+                    self._user, 'client-certificate',
+                    file_base_path=self._config_base_path).as_file()
+                self.key_file = FileOrData(
+                    self._user, 'client-key',
+                    file_base_path=self._config_base_path).as_file()
+        if 'insecure-skip-tls-verify' in self._cluster:
+            self.verify_ssl = not self._cluster['insecure-skip-tls-verify']
+
+    def _set_config(self, client_configuration):
+        if 'token' in self.__dict__:
+            client_configuration.api_key['authorization'] = self.token
+        # copy these keys directly from self to configuration object
+        keys = ['host', 'ssl_ca_cert', 'cert_file', 'key_file', 'verify_ssl']
+        for key in keys:
+            if key in self.__dict__:
+                setattr(client_configuration, key, getattr(self, key))
+
+    def load_and_set(self, client_configuration):
+        self._load_cluster_info()
+        self._set_config(client_configuration)
+
+    def list_contexts(self):
+        return [context.value for context in self._config['contexts']]
+
+    @property
+    def current_context(self):
+        return self._current_context.value
+
+
+class ConfigNode(object):
+    """Remembers each config key's path and construct a relevant exception
+    message in case of missing keys. The assumption is all access keys are
+    present in a well-formed kube-config."""
+
+    def __init__(self, name, value):
+        self.name = name
+        self.value = value
+
+    def __contains__(self, key):
+        return key in self.value
+
+    def __len__(self):
+        return len(self.value)
+
+    def safe_get(self, key):
+        if (isinstance(self.value, list) and isinstance(key, int) or
+                key in self.value):
+            return self.value[key]
+
+    def __getitem__(self, key):
+        v = self.safe_get(key)
+        if not v:
+            raise ConfigException(
+                'Invalid kube-config file. Expected key %s in %s'
+                % (key, self.name))
+        if isinstance(v, dict) or isinstance(v, list):
+            return ConfigNode('%s/%s' % (self.name, key), v)
+        else:
+            return v
+
+    def get_with_name(self, name, safe=False):
+        if not isinstance(self.value, list):
+            raise ConfigException(
+                'Invalid kube-config file. Expected %s to be a list'
+                % self.name)
+        result = None
+        for v in self.value:
+            if 'name' not in v:
+                raise ConfigException(
+                    'Invalid kube-config file. '
+                    'Expected all values in %s list to have \'name\' key'
+                    % self.name)
+            if v['name'] == name:
+                if result is None:
+                    result = v
+                else:
+                    raise ConfigException(
+                        'Invalid kube-config file. '
+                        'Expected only one object with name %s in %s list'
+                        % (name, self.name))
+        if result is not None:
+            return ConfigNode('%s[name=%s]' % (self.name, name), result)
+        if safe:
+            return None
+        raise ConfigException(
+            'Invalid kube-config file. '
+            'Expected object with name %s in %s list' % (name, self.name))
+
+
+class FileOrData(object):
+    """Utility class to read content of obj[%data_key_name] or file's
+     content of obj[%file_key_name] and represent it as file or data.
+     Note that the data is preferred. The obj[%file_key_name] will be used iff
+     obj['%data_key_name'] is not set or empty. Assumption is file content is
+     raw data and data field is base64 string. The assumption can be changed
+     with base64_file_content flag. If set to False, the content of the file
+     will assumed to be base64 and read as is. The default True value will
+     result in base64 encode of the file content after read."""
+
+    def __init__(self, obj, file_key_name, data_key_name=None,
+                 file_base_path="", base64_file_content=True):
+        if not data_key_name:
+            data_key_name = file_key_name + "-data"
+        self._file = None
+        self._data = None
+        self._base64_file_content = base64_file_content
+        if data_key_name in obj:
+            self._data = obj[data_key_name]
+        elif file_key_name in obj:
+            self._file = os.path.normpath(
+                os.path.join(file_base_path, obj[file_key_name]))
+
+    def as_file(self):
+        """If obj[%data_key_name] exists, return name of a file with base64
+        decoded obj[%data_key_name] content otherwise obj[%file_key_name]."""
+        use_data_if_no_file = not self._file and self._data
+        if use_data_if_no_file:
+            if self._base64_file_content:
+                if isinstance(self._data, str):
+                    content = self._data.encode()
+                else:
+                    content = self._data
+                self._file = _create_temp_file_with_content(
+                    base64.standard_b64decode(content))
+            else:
+                self._file = _create_temp_file_with_content(self._data)
+        if self._file and not os.path.isfile(self._file):
+            raise ConfigException("File does not exists: %s" % self._file)
+        return self._file
+
+    def as_data(self):
+        """If obj[%data_key_name] exists, Return obj[%data_key_name] otherwise
+        base64 encoded string of obj[%file_key_name] file content."""
+        use_file_if_no_data = not self._data and self._file
+        if use_file_if_no_data:
+            with open(self._file) as f:
+                if self._base64_file_content:
+                    self._data = bytes.decode(
+                        base64.standard_b64encode(str.encode(f.read())))
+                else:
+                    self._data = f.read()
+        return self._data

--- a/virtwho/virt/kubevirt/kubevirt.py
+++ b/virtwho/virt/kubevirt/kubevirt.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2018 Red Hat, Inc.
+# Copyright 2019 Red Hat, Inc.
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -23,6 +23,7 @@ import os.path
 
 from virtwho import virt
 from virtwho.config import VirtConfigSection
+from virtwho.virt.kubevirt.client import KubeClient
 
 
 class KubevirtConfigSection(VirtConfigSection):
@@ -42,7 +43,7 @@ class KubevirtConfigSection(VirtConfigSection):
         return: Return None or info/warning/error
         """
         path = self._values[key]
-        if os.path.isfile(path):
+        if not os.path.isfile(path):
             return [(
                     'warning',
                     "Kubeconfig file was not found at %s" % path
@@ -60,40 +61,11 @@ class Kubevirt(virt.Virt):
                                        terminate_event=terminate_event,
                                        interval=interval,
                                        oneshot=oneshot)
-        self.path = self.config['kubeconfig']
+        self._path = self.config['kubeconfig']
 
     def prepare(self):
-        self.kubevirt_api = self.virt()
-        self.kube_api = self.kube()
+        self._client = KubeClient(self._path)
 
-    def virt(self):
-        try:
-            from kubernetes import config
-            import kubevirt
-        except ImportError:
-            self.logger.warning("The kubevirt-python or the kubernetes-python package is missing")
-            self.stop()
-
-        cl = config.kube_config._get_kube_config_loader_for_yaml_file(self.path)
-        cl.load_and_set(kubevirt.configuration)
-        return kubevirt.DefaultApi()
-
-    def kube(self):
-        try:
-            from kubernetes import client, config
-        except ImportError:
-            self.logger.warning("The kubevirt-python or the kubernetes-python package is missing")
-            self.stop()
-
-        config.load_kube_config(config_file=self.path)
-        return client.CoreV1Api()
-
-    def get_nodes(self):
-        return self.kube_api.list_node()
-
-    def get_vms(self):
-        return self.kubevirt_api.list_virtual_machine_instance_for_all_namespaces()
-    
     def getHostGuestMapping(self):
         """
         Returns dictionary containing a list of virt.Hypervisors
@@ -105,31 +77,31 @@ class Kubevirt(virt.Virt):
         """
         hosts = {}
 
-        nodes = self.get_nodes()
-        vms = self.get_vms()
+        nodes = self._client.get_nodes()
+        vms = self._client.get_vms()
 
-        for node in nodes.items:
-            status = node.status
-            version = status.node_info.kubelet_version
-            name = node.metadata.name
-            host_id = status.node_info.machine_id
-            address = status.addresses[0].address
+        for node in nodes['items']:
+            status = node['status']
+            version = status['nodeInfo']['kubeletVersion']
+            name = node['metadata']['name']
+            host_id = status['nodeInfo']['machineID']
+            address = status['addresses'][0]['address']
             facts = {
-                virt.Hypervisor.CPU_SOCKET_FACT: status.allocatable["cpu"],
+                virt.Hypervisor.CPU_SOCKET_FACT: status['allocatable']["cpu"],
                 virt.Hypervisor.HYPERVISOR_TYPE_FACT: 'qemu',
                 virt.Hypervisor.HYPERVISOR_VERSION_FACT: version
             }
             hosts[name] = virt.Hypervisor(hypervisorId=host_id, name=address, facts=facts)
-        
-        for vm in vms.items:
-            metadata = vm.metadata
-            host_name = vm.status.node_name
+
+        for vm in vms['items']:
+            metadata = vm['metadata']
+            host_name = vm['status']['nodeName']
 
             # a vm is not scheduled on any hosts
             if host_name is None:
                 continue
 
-            guest_id = metadata.namespace + '/' + metadata.name
+            guest_id = metadata['namespace'] + '/' + metadata['name']
             # a vm is always in running state
             status = virt.Guest.STATE_RUNNING
             hosts[host_name].guestIds.append(virt.Guest(guest_id, self.CONFIG_TYPE, status))


### PR DESCRIPTION
It is common practice in virt-who not to rely on external dependencies.
This PR removes dependency on kubevirt-python and the kubernetes-python.

Fixes: https://bugzilla.redhat.com/1656265
Fixes: https://bugzilla.redhat.com/1684499