### PR TITLE
1695519: use correct uuid in kubevirt report

### DIFF
--- a/tests/test_kubevirt.py
+++ b/tests/test_kubevirt.py
@@ -69,6 +69,29 @@ class TestKubevirt(TestBase):
                 'name': 'win-2016',
                 'namespace': 'default',
             },
+            'spec': {
+                'domain': {
+                    'devices': {
+                        'disks': [
+                            {'disk': {'bus': 'virtio'}, 'name': 'containerdisk'}
+                        ],
+                        'interfaces': [
+                            {'bridge': {}, 'name': 'default'}
+                        ],
+                    },
+                    'features': {
+                        'acpi': {
+                            'enabled': 'true'
+                        }
+                    },
+                    'firmware': {
+                        'uuid': 'f83c5f73-5244-4bd1-90cf-02bac2dda608'
+                    },
+                    'machine': {
+                        'type': 'q35'
+                    }
+                }
+            },
             'status': {
                 'nodeName': 'master',
             }
@@ -88,7 +111,7 @@ class TestKubevirt(TestBase):
             name='master',
             guestIds=[
                 Guest(
-                    'default/win-2016',
+                    'f83c5f73-5244-4bd1-90cf-02bac2dda608',
                     self.kubevirt.CONFIG_TYPE,
                     Guest.STATE_RUNNING,
                 )

--- a/virtwho/virt/kubevirt/kubevirt.py
+++ b/virtwho/virt/kubevirt/kubevirt.py
@@ -94,14 +94,14 @@ class Kubevirt(virt.Virt):
             hosts[name] = virt.Hypervisor(hypervisorId=host_id, name=address, facts=facts)
 
         for vm in vms['items']:
-            metadata = vm['metadata']
+            spec = vm['spec']
             host_name = vm['status']['nodeName']
 
             # a vm is not scheduled on any hosts
             if host_name is None:
                 continue
 
-            guest_id = metadata['namespace'] + '/' + metadata['name']
+            guest_id = spec['domain']['firmware']['uuid']
             # a vm is always in running state
             status = virt.Guest.STATE_RUNNING
             hosts[host_name].guestIds.append(virt.Guest(guest_id, self.CONFIG_TYPE, status))


### PR DESCRIPTION
We used 'namespace/name' as guest_id which is not correct. This PR
changes it to use firmware uuid instead.