### PR TITLE
1641953: Virt-who fails if one hypervisor has wrong encrypted password

### DIFF
--- a/tests/test_config_section_virt.py
+++ b/tests/test_config_section_virt.py
@@ -352,3 +352,20 @@ class TestVirtConfigSection(TestBase):
         ]
         result = self.virt_config._validate_filter('filter_hosts')
         self.assertIsNotNone(result)
+
+    def test_validate_wrong_values_in_encrypted_password(self):
+        """
+        Test of validation of corrupted encrypted password
+        """
+        self.init_virt_config_section()
+        self.mock_pwd_file()
+        # Safe current password
+        password = self.virt_config['password']
+        # Delete unencrypted password first
+        del self.virt_config['password']
+        # Set up corrupted encrypted password
+        self.virt_config['encrypted_password'] = 'xxxx'
+        # Do own testing here
+        result = self.virt_config._validate_encrypted_password('encrypted_password')
+        self.assertIsNotNone(result)
+        self.unmock_pwd_file()

--- a/virtwho/config.py
+++ b/virtwho/config.py
@@ -30,6 +30,7 @@ DEFAULTSECT
 from virtwho import log, SAT5, SAT6
 from .password import Password
 from binascii import unhexlify
+from binascii import Error as BinasciiError
 from . import util
 
 try:
@@ -1048,7 +1049,7 @@ class VirtConfigSection(ConfigSection):
         else:
             try:
                 self._values[decrypted_pass_key] = Password.decrypt(unhexlify(pwd))
-            except (TypeError, IndexError, UnicodeDecodeError):
+            except (TypeError, IndexError, UnicodeDecodeError, BinasciiError):
                 result = (
                     'warning',
                     "Option \"{option}\" cannot be decrypted, possibly corrupted"


### PR DESCRIPTION
In python3 an error can be thrown on incorrect encrypted password that was not previously accounted for.