### PR TITLE
1708534: add kubeconfig to template

### DIFF
--- a/template.conf
+++ b/template.conf
@@ -16,6 +16,7 @@
 #owner=              ; owner for use with SAM, Customer Portal, or Satellite 6
 #env=                ; environment for use with SAM, Customer Portal, or Satellite 6
 #hypervisor_id=      ; how will be the hypervisor identified, one of: uuid, hostname, hwuuid
+#kubeconfig=         : path to kubernetes configuration file - kubevirt specific option
 
 ## For complete list of options, see virt-who-config(5) manual page.
 
@@ -35,3 +36,6 @@
 #rhsm_username=
 #rhsm_encrypted_password=
 #rhsm_prefix=/rhsm
+#
+## Configuring virt-who to connect to Kubevirt
+#kubeconfig=

--- a/virt-who-config.5
+++ b/virt-who-config.5
@@ -137,6 +137,9 @@ When this propery is not set, then virt-who tries to detect wildcards or regular
 .TP
 \fBhypervisor_id\fR
 Property that should be used as identification of the hypervisor. Can be one of following: \fBuuid\fR, \fBhostname\fR, \fBhwuuid\fR. Note that some virtualization backends don't have all of them implemented. Default is \fBuuid\fR. \fBhwuuid\fR is applicable to esx and rhevm only. This property is meant to be set up before initial run of virt-who. Changing it later will result in duplicated entries in the subscription manager.
+.TP
+\fB#kubeconfig\fR
+Path to Kubernetes configuration file which contains authentication and connection details. Used by kubevirt option
 
 .SH EXAMPLE
 [test-esx]


### PR DESCRIPTION
We need to make configuration template complete. kubeconfig option was
missing and it was added to the file.

Fixes: https://bugzilla.redhat.com/1708534