### PR TITLE
1652549: Add heartbeat call to virt-who cycle

### DIFF
--- a/tests/test_subscriptionmanager.py
+++ b/tests/test_subscriptionmanager.py
@@ -107,6 +107,20 @@ class TestSubscriptionManager(TestBase):
         self.sm.connection.return_value.has_capability = MagicMock(return_value=False)
 
     @patch('rhsm.connection.UEPConnection')
+    # def test_hypervisorHeartbeat(self):
+    def test_hypervisorHeartbeat(self, rhsmconnection):
+        owner = 'owner'
+        config = VirtConfigSection.from_dict({'type': 'libvirt', 'owner': owner}, 'test', None)
+        # Ensure we try out the new API
+        rhsmconnection.return_value.has_capability.return_value = True
+        self.sm.logger = MagicMock()
+        self.sm.hypervisorHeartbeat(config, options=None)
+        self.sm.connection.hypervisorHeartbeat.assert_called_with(
+            owner,
+            None
+        )
+
+    @patch('rhsm.connection.UEPConnection')
     def test_job_status(self, rhsmconnection):
         rhsmconnection.return_value.has_capability.return_value = True
         config = VirtConfigSection.from_dict({'type': 'libvirt', 'owner': 'owner'}, 'test', None)

--- a/virt-who.spec
+++ b/virt-who.spec
@@ -49,9 +49,9 @@ Requires:       libvirt-python
 # python-rhsm 1.20 has the M2Crypto wrappers needed to replace M2Crypto
 # with the python standard libraries where plausible
 %if %{use_python3}
-Requires:       python3-subscription-manager-rhsm
+Requires:       python3-subscription-manager-rhsm > 1.25.6
 %else
-Requires:       subscription-manager-rhsm
+Requires:       subscription-manager-rhsm > 1.25.6
 %endif
 # python-suds is required for vSphere support
 Requires:       %{python_ver}-suds

--- a/virtwho/manager/subscriptionmanager/subscriptionmanager.py
+++ b/virtwho/manager/subscriptionmanager/subscriptionmanager.py
@@ -247,6 +247,17 @@ class SubscriptionManager(Manager):
             report.state = AbstractVirtReport.STATE_FINISHED
         return result
 
+    def hypervisorHeartbeat(self, config, options=None):
+        if options:
+            named_options = NamedOptions()
+            for key, value in options['global'].items():
+                setattr(named_options, key, value)
+        else:
+            named_options = None
+
+        connection = self._connect(config)
+        connection.hypervisorHeartbeat(config['owner'], named_options)
+
     def _is_rhsm_server_async(self, report, connection=None):
         """
         Check if server has capability 'hypervisor_async'.

--- a/virtwho/virt/virt.py
+++ b/virtwho/virt/virt.py
@@ -596,6 +596,11 @@ class DestinationThread(IntervalThread):
         @param data_to_send: A dict of source_keys, report
         @type: dict
         """
+
+        if not isinstance(data_to_send, ErrorReport):
+            # Ping all hypervisors for this reporter to update check in time regardless of change
+            self.dest.hypervisorHeartbeat(config=self.config, options=self.options)
+
         if not data_to_send:
             self.logger.debug('No data to send, waiting for next interval')
             return


### PR DESCRIPTION
This ensures that hypervisors will have updated lastcheckin times even
 if they show no changes on the hypervisor checkins.


