### PR TITLE
1472727: Log error, when encrypted password is missing; ENT-1344

### DIFF
--- a/tests/test_config_section_virt.py
+++ b/tests/test_config_section_virt.py
@@ -156,6 +156,24 @@ class TestVirtConfigSection(TestBase):
         self.assertEqual(password, decrypted_password)
         self.unmock_pwd_file()
 
+    def test_validate_encrypted_password_missing_key(self):
+        """
+        Test of validation of encrypted password
+        """
+        self.init_virt_config_section()
+        self.mock_pwd_file()
+        # Safe current password
+        password = self.virt_config['password']
+        # Delete unencrypted password first
+        del self.virt_config['password']
+        # Set up encrypted password
+        self.virt_config['encrypted_password'] = hexlify(Password.encrypt(password))
+        # Simulate deleting of key file
+        Password.KEYFILE = '/path/to/file/that/does/not/exists'
+        # Do own testing here
+        result = self.virt_config._validate_encrypted_password('encrypted_password')
+        self.assertIsNotNone(result)
+
     def test_validate_missing_encrypted_password(self):
         """
         Test of validation of missing encrypted password

--- a/virtwho/config.py
+++ b/virtwho/config.py
@@ -28,7 +28,7 @@ import uuid
 from six.moves.configparser import SafeConfigParser, NoOptionError, Error, MissingSectionHeaderError, ParsingError,\
 DEFAULTSECT
 from virtwho import log, SAT5, SAT6
-from .password import Password
+from .password import Password, InvalidKeyFile
 from binascii import unhexlify
 from binascii import Error as BinasciiError
 from . import util
@@ -1046,6 +1046,11 @@ class VirtConfigSection(ConfigSection):
                     'warning',
                     "Option \"{option}\" cannot be decrypted, possibly corrupted"
                     .format(option=pass_key)
+                )
+            except InvalidKeyFile as err:
+                result = (
+                    'error',
+                    "Unable to read key file: %s" % str(err)
                 )
         return result
 

--- a/virtwho/password/__init__.py
+++ b/virtwho/password/__init__.py
@@ -44,7 +44,6 @@ class UnwritableKeyFile(Exception):
     pass
 
 
-
 class Password(object):
     KEYFILE = '/var/lib/virt-who/key'
     ENCRYPT = 1


### PR DESCRIPTION
* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1472727
* When key file for encrypted password is missing, then do not
  crash virt-who, but skip given host and print error to log file.
* Added one unit tests for this case.