### PR TITLE
Handle when hyperV instance["BIOSGUID"] returns None causing virt-who to crash

### DIFF
--- a/virtwho/virt/hyperv/hyperv.py
+++ b/virtwho/virt/hyperv/hyperv.py
@@ -583,7 +583,8 @@ class HyperV(virt.Virt):
         for instance in hypervsoap.Pull(uuid):
             try:
                 uuid = instance["BIOSGUID"]
-            except KeyError:
+                assert uuid is not None
+            except (KeyError, AssertionError):
                 self.logger.warning("Guest without BIOSGUID found, ignoring")
                 continue
 


### PR DESCRIPTION
When the instance's BIOSGUID field is None, a KeyError will not be raised, so None gets passed to decodeWinUUID() which causes an error. Let's treat a BIOSGUID of None like a missing BIOSGUID. Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1718039.