### PR TITLE
1499679: Check for duplicates in conf file; ENT-249

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -220,6 +220,22 @@ owner=root
         # If there is a config file but it is bad, then no config is returned
         self.assertEqual(len(manager.configs), 0)
 
+    def test_config_duplicate_keys(self):
+        filename = os.path.join(self.config_dir, "test.conf")
+        with open(filename, "w") as f:
+            f.write("""
+[test]
+type=esx
+server=1.2.3.4
+username=admin
+password=password
+owner=root
+owner=tester
+""")
+        manager = DestinationToSourceMapper(init_config({}, {}, config_dir=self.config_dir))
+        self.assertEqual(len(manager.configs), 1)
+        self.assertEqual(manager.configs[0][1]['owner'], 'tester')
+
     @patch('virtwho.password.Password._read_key_iv')
     def testCryptedPassword(self, password):
         password.return_value = (hexlify(Password._generate_key()), hexlify(Password._generate_key()))

--- a/tests/test_config_section_virt.py
+++ b/tests/test_config_section_virt.py
@@ -198,9 +198,12 @@ class TestVirtConfigSection(TestBase):
         self.virt_config['encrypted_password'] = hexlify(corrupted_encrypted_pwd)
         # Do own testing here
         result = self.virt_config._validate_encrypted_password('encrypted_password')
-        self.assertIsNone(result)
-        decrypted_password = self.virt_config.get('password')
-        self.assertNotEqual(password, decrypted_password)
+        # It is interesting that decryption of corrupted password is successful sometimes and sometimes not
+        if result is not None:
+            self.assertEqual(result, ('warning', 'Option "encrypted_password" cannot be decrypted, possibly corrupted'))
+        else:
+            decrypted_password = self.virt_config.get('password')
+            self.assertNotEqual(password, decrypted_password)
         self.unmock_pwd_file()
 
     def test_validate_correct_username(self):


### PR DESCRIPTION
* Warning is printed for Python 3, when there is duplicate key.
  When there are more duplicated keys, then the warning is not
  printed.
* It is not possible to implement this for Python 2 without
  reimplementing parsing of config file.
* Added one unit test for duplicated key
* Fixed one unit test for corrupted encrypted pasword
