### PR TITLE
1720154: Provide SYSTEM_UUID_FACT

### DIFF
--- a/tests/test_kubevirt.py
+++ b/tests/test_kubevirt.py
@@ -122,6 +122,7 @@ class TestKubevirt(TestBase):
                 facts={
                     Hypervisor.CPU_SOCKET_FACT: '2',
                     Hypervisor.HYPERVISOR_TYPE_FACT: 'qemu',
+                    Hypervisor.SYSTEM_UUID_FACT: '52c01ad890e84b15a1be4be18bd64ecd',
                     Hypervisor.HYPERVISOR_VERSION_FACT: 'v1.9.1+a0ce1bc657',
                 }
             )
@@ -155,6 +156,7 @@ class TestKubevirt(TestBase):
                 facts={
                     Hypervisor.CPU_SOCKET_FACT: '2',
                     Hypervisor.HYPERVISOR_TYPE_FACT: 'qemu',
+                    Hypervisor.SYSTEM_UUID_FACT: '52c01ad890e84b15a1be4be18bd64ecd',
                     Hypervisor.HYPERVISOR_VERSION_FACT: 'v1.9.1+a0ce1bc657',
                 }
             )

--- a/virtwho/virt/kubevirt/kubevirt.py
+++ b/virtwho/virt/kubevirt/kubevirt.py
@@ -99,6 +99,8 @@ class Kubevirt(virt.Virt):
             facts = {
                 virt.Hypervisor.CPU_SOCKET_FACT: status['allocatable']["cpu"],
                 virt.Hypervisor.HYPERVISOR_TYPE_FACT: 'qemu',
+                # this should be hardware uniqe identifier but k8s api gives us only machineID
+                virt.Hypervisor.SYSTEM_UUID_FACT: status['nodeInfo']['machineID'],
                 virt.Hypervisor.HYPERVISOR_VERSION_FACT: version
             }
             hosts[name] = virt.Hypervisor(hypervisorId=host_id, name=name, facts=facts)


### PR DESCRIPTION
Hostnames can be changed so we need to make sure to use uniqe identifier.
Kubernetes api provides only machineID which can be used in this context.

Fixes: https://bugzilla.redhat.com/1720154