### PR TITLE
1720048: Template for general configuration not properly formatted

### DIFF
--- a/template-general.conf
+++ b/template-general.conf
@@ -22,7 +22,7 @@
 #log_dir=               ; The absolute path of the directory to write logs to.
 #log_file=              ; The file name to write logs to (used only if log_per_config=False)
 #print_=True            ; Print the host/guest association obtained from virtualization backend to standard out.
-                        ;  This only applies to a command line execution (implies oneshot)
+#                       ;  This only applies to a command line execution (implies oneshot)
 #configs=               ; A list of files containing configurations for virt-who
 #                       ; Used to specify locations other than default
 


### PR DESCRIPTION
If used as written, it will not be readable by the parser