### PR TITLE
1733286: add connection/request timeout

### DIFF
--- a/virtwho/virt/kubevirt/client.py
+++ b/virtwho/virt/kubevirt/client.py
@@ -24,8 +24,11 @@ import ssl
 import urllib3
 
 from six import PY3
+from urllib3.util.timeout import Timeout
 
 from virtwho.virt.kubevirt import config
+
+_TIMEOUT = 60
 
 
 class KubeClient:
@@ -73,10 +76,12 @@ class KubeClient:
         url = self.host + path
 
         try:
+            timeout = Timeout(connect=_TIMEOUT, read=_TIMEOUT)
             r = self._pool_manager.request("GET", url,
                                           fields=None,
                                           preload_content=True,
-                                          headers=header_params)
+                                          headers=header_params,
+                                          timeout=timeout)
         except urllib3.exceptions.SSLError as e:
             msg = "{0}\n{1}".format(type(e).__name__, str(e))
             raise ApiException(status=0, reason=msg)


### PR DESCRIPTION
We need to make sure that kubevirt behaves in the same way as any other plugin. OS level defaults are not enough and we need to respect provided interval. We align the timeout with esxi plugin to 60 seconds even if other plugins use different value.

Bug-Url: https://bugzilla.redhat.com/1733286
Signed-off-by: Piotr Kliczewski <piotr.kliczewski@gmail.com>