### PR TITLE
1751624: Allow unicode username only if python-requests allows it

### DIFF
--- a/tests/test_config_section_virt.py
+++ b/tests/test_config_section_virt.py
@@ -22,7 +22,7 @@ Test validating of VirtConfigSection
 """
 
 from base import TestBase
-from mock import MagicMock
+from mock import MagicMock,patch
 
 import tempfile
 import os
@@ -223,15 +223,23 @@ class TestVirtConfigSection(TestBase):
         result = self.virt_config._validate_username('username')
         self.assertIsNotNone(result)
 
-    def test_validate_wrong_username(self):
+    @patch ('virtwho.config.requests')
+    def test_validate_unicode_username(self, _mock_requests):
         """
-        Test validation of wrong username (containing e.g. UTF-8 string)
+        Test validation of unicode username (containing e.g. UTF-8 string)
+        Passes or fails based on python-requests version
         """
         self.init_virt_config_section()
         # First, change username to something exotic ;-)
         self.virt_config['username'] = 'Jiří'
+        # Verision that can't handle unicode
+        _mock_requests.__version__ = '2.19.0'
         result = self.virt_config._validate_username('username')
         self.assertIsNotNone(result)
+        # Verision that can handle unicode
+        _mock_requests.__version__ = '2.21.0'
+        result = self.virt_config._validate_username('username')
+        self.assertIsNone(result)
 
     def test_validate_server(self):
         """

--- a/virtwho/config.py
+++ b/virtwho/config.py
@@ -24,6 +24,7 @@ import collections
 import six
 import os
 import uuid
+import requests
 
 from six.moves.configparser import SafeConfigParser, NoOptionError, Error, MissingSectionHeaderError
 try:
@@ -1088,11 +1089,14 @@ class VirtConfigSection(ConfigSection):
         else:
             if username != NotSetSentinel:
                 try:
-                    username.encode('latin1')
+                    # this is conditional based on the version of python-requests we are using.
+                    major, minor, patch = [int(part) for part in requests.__version__.split('.')]
+                    if (major,minor) < (2,20):
+                        username.encode('latin1')
                 except (UnicodeEncodeError, UnicodeDecodeError):
                     result = (
-                        'warning',
-                        "Value: {0} of option '{1}': is not in latin1 encoding".format(
+                        'error',
+                        "Value: {0} of option '{1}': is not in latin1 encoding. That is not allowed on this system.".format(
                             username,
                             username_key
                         )


### PR DESCRIPTION
Version 2.20 and above can handle unicode usernames.