### PR TITLE
1751441: remove strict need for kubeconfig

### DIFF
--- a/tests/test_kubevirt.py
+++ b/tests/test_kubevirt.py
@@ -162,3 +162,10 @@ class TestKubevirt(TestBase):
             )
             result = kubevirt.getHostGuestMapping()['hypervisors'][0]
             self.assertEqual(expected_result.toDict(), result.toDict())
+
+    def test_empty_kubeconfig(self):
+        config = self.create_config(name='test', wrapper=None, type='kubevirt',
+                                    owner='owner')
+
+        kubevirt = Virt.from_config(self.logger, config, Datastore())
+        self.assertEqual("~/.kube/config", kubevirt._path)

--- a/virtwho/virt/kubevirt/config.py
+++ b/virtwho/virt/kubevirt/config.py
@@ -27,7 +27,6 @@ import urllib3
 import yaml
 
 
-KUBE_CONFIG_DEFAULT_LOCATION = os.environ.get('KUBECONFIG', '~/.kube/config')
 _temp_files = {}
 
 

--- a/virtwho/virt/kubevirt/kubevirt.py
+++ b/virtwho/virt/kubevirt/kubevirt.py
@@ -19,6 +19,7 @@
 #
 from __future__ import absolute_import
 
+import os
 import os.path
 
 from virtwho import virt
@@ -36,7 +37,10 @@ class KubevirtConfigSection(VirtConfigSection):
                                                     wrapper,
                                                     *args,
                                                     **kwargs)
-        self.add_key('kubeconfig', validation_method=self._validate_path, required=True)
+        self.add_key('kubeconfig',
+                     validation_method=self._validate_path,
+                     default=os.environ.get('KUBECONFIG', '~/.kube/config'),
+                     required=False)
 
     def _validate_path(self, key='kubeconfig'):
         """


### PR DESCRIPTION
We want to use default value if kubeconfig parameter is not provided.