### PR TITLE
1776084 - Failed to run virt-who with Hyper-V

### DIFF
--- a/virtwho/virt/hyperv/ntlm.py
+++ b/virtwho/virt/hyperv/ntlm.py
@@ -260,7 +260,10 @@ class NegotiateMessage(OutgoingMessage):
             self.params['negotiate_flags'] = self.DEFAULTS['negotiate_flags']
         if domain_len > 0:
             self.params['negotiate_flags'] |= NTLM_NegotiateOemDomainSupplied
-        return OutgoingMessage._format(self) + self.domain.encode('utf-8') + self.workstation.encode('utf-8')
+        if six.PY3:
+            return OutgoingMessage._format(self) + self.domain + self.workstation
+        else:
+            return OutgoingMessage._format(self) + self.domain.encode('utf-8') + self.workstation.encode('utf-8')
 
 
 class ChallengeMessage(IncomingMessage):


### PR DESCRIPTION
utf-8 encode is not necessary in python3