### PR TITLE
1762780: fix bug, when reporter_id is empty; ENT-1706

### DIFF
--- a/tests/test_config_section.py
+++ b/tests/test_config_section.py
@@ -141,16 +141,54 @@ class TestConfigSection(TestBase):
         self.my_config = MyConfigSection(MY_SECTION_NAME, None)
         # Add required option and one with default value
         self.my_config['must_have'] = 'foo'
-        # Add one option with default value, but not other options
+        # Add one option with default value, but not the other options (my_list and my_str)
         self.my_config['my_bool'] = True
         result = self.my_config.validate()
         expected_result = [
             ('debug', 'Value for "my_list" not set, using default: []'),
-            ('debug', 'Value for "my_str" not set, using default: bar'),
+            ('debug', 'Value for "my_str" not set, using default: bar')
         ]
         # We do not particularly care about the ordering here, just that the lists contain the same
         # elements.
         six.assertCountEqual(self, result, expected_result)
+        self.assertEqual(self.my_config['my_str'], 'bar')
+        self.assertEqual(self.my_config.state, ValidationState.VALID)
+
+    def test_validate_empty_string_with_default_value(self):
+        """
+        Test validation, when there is empty string with defined default value
+        """
+        self.my_config = MyConfigSection(MY_SECTION_NAME, None)
+        # Add required option and one with default value
+        self.my_config['must_have'] = 'foo'
+        # Add one option with default value, but not the other options (my_list and my_str)
+        self.my_config['my_bool'] = True
+        self.my_config['my_list'] = ['foo', 'bar']
+        self.my_config['my_str'] = ''
+        result = self.my_config.validate()
+        expected_result = [
+            ('warning', '"my_str" cannot be empty, using default: "bar"')
+        ]
+        self.assertEqual(result, expected_result)
+        self.assertEqual(self.my_config['my_str'], 'bar')
+        self.assertEqual(self.my_config.state, ValidationState.VALID)
+
+    def test_validate_wrong_string_with_default_value(self):
+        """
+        Test validation, when there is empty string with defined default value
+        """
+        self.my_config = MyConfigSection(MY_SECTION_NAME, None)
+        # Add required option and one with default value
+        self.my_config['must_have'] = 'foo'
+        # Add one option with default value, but not the other options (my_list and my_str)
+        self.my_config['my_bool'] = True
+        self.my_config['my_list'] = ['foo', 'bar']
+        self.my_config['my_str'] = ['foo', 'Foo']
+        result = self.my_config.validate()
+        expected_result = [
+            ('warning', '"my_str" is not set to a valid string, using default: "bar"')
+        ]
+        self.assertEqual(result, expected_result)
         self.assertEqual(self.my_config['my_str'], 'bar')
         self.assertEqual(self.my_config.state, ValidationState.VALID)
 

--- a/tests/test_virtwho.py
+++ b/tests/test_virtwho.py
@@ -62,7 +62,7 @@ class TestOptions(TestBase):
         self.assertFalse(options[VW_GLOBAL]['debug'])
         self.assertFalse(options[VW_GLOBAL]['oneshot'])
         self.assertEqual(options[VW_GLOBAL]['interval'], 3600)
-        self.assertEqual(options[VW_GLOBAL]['reporter_id'], util.generateReporterId())
+        self.assertEqual(options[VW_GLOBAL]['reporter_id'], util.generate_reporter_id())
 
     @patch('virtwho.log.getLogger')
     @patch('virtwho.config.parse_file')
@@ -173,7 +173,7 @@ class TestOptions(TestBase):
         parseFile.side_effect = lambda x: {}
 
         _, options = parse_options()
-        self.assertEqual(options[VW_GLOBAL]['reporter_id'], util.generateReporterId())
+        self.assertEqual(options[VW_GLOBAL]['reporter_id'], util.generate_reporter_id())
 
     @patch('virtwho.log.getLogger')
     @patch('virtwho.config.parse_file')

--- a/virtwho/config.py
+++ b/virtwho/config.py
@@ -825,9 +825,18 @@ class ConfigSection(collections.MutableMapping):
                 result = ('warning', 'Value for %s not set' % key)
         else:
             if not isinstance(value, str):
-                result = ('warning', '%s is not set to a valid string, using default' % key)
+                if self.has_default(key):
+                    self._values[key] = self.defaults[key]
+                    result = ('warning', '"%s" is not set to a valid string, using default: "%s"' %
+                              (key, self.defaults[key]))
+                else:
+                    result = ('warning', '"%s" is not set to a valid string and has no default value' % key)
             elif len(value) == 0:
-                result = ('warning', '%s cannot be empty, using default' % key)
+                if self.has_default(key):
+                    self._values[key] = self.defaults[key]
+                    result = ('warning', '"%s" cannot be empty, using default: "%s"' % (key, self.defaults[key]))
+                else:
+                    result = ('warning', '"%s" cannot be empty and has no default value' % key)
         return result
 
     def _validate_list(self, list_key):
@@ -1214,7 +1223,7 @@ class GlobalSection(ConfigSection):
         self.add_key('log_per_config', validation_method=self._validate_str_to_bool, default=False)
         self.add_key('configs', validation_method=self._validate_list, default=[])
         self.add_key('reporter_id', validation_method=self._validate_non_empty_string,
-                     default=util.generateReporterId())
+                     default=util.generate_reporter_id())
         self.add_key('interval',  validation_method=self._validate_interval, default=DefaultInterval)
         self.add_key('log_file', validation_method=self._validate_non_empty_string, default=log.DEFAULT_LOG_FILE)
         self.add_key('log_dir', validation_method=self._validate_non_empty_string, default=log.DEFAULT_LOG_DIR)
@@ -1226,7 +1235,7 @@ class GlobalSection(ConfigSection):
         except (TypeError, ValueError) as e:
             self._values[key] = 0
         except KeyError:
-            return ('warning', '%s is missing' % key)
+            return 'warning', '%s is missing' % key
 
         if self._values[key] < MinimumSendInterval:
             message = "Interval value can't be lower than {min} seconds. Default value of " \
@@ -1244,6 +1253,7 @@ class GlobalSection(ConfigSection):
 
         if self.get('print_', None) or self.get('print', None):
             self._values['oneshot'] = True
+
 
 # String representations of all the default configuration for virt-who
 DEFAULTS = {

--- a/virtwho/util.py
+++ b/virtwho/util.py
@@ -24,7 +24,7 @@ else:
     from string import ascii_letters as letters
 
 
-__all__ = ('OrderedDict', 'decode', 'generateReporterId', 'clean_filename', 'RequestsXmlrpcTransport')
+__all__ = ('OrderedDict', 'decode', 'generate_reporter_id', 'clean_filename', 'RequestsXmlrpcTransport')
 
 
 class Singleton(ABCMeta):
@@ -359,7 +359,7 @@ def clean_filename(name):
     return ''.join([char for char in name if char in VALID_FILENAME_CHARS])
 
 
-def getMachineId():
+def get_machine_id():
     try:
         with open('/etc/machine-id') as machine_id_file:
             machine_id = machine_id_file.readline().strip()
@@ -368,9 +368,9 @@ def getMachineId():
     return machine_id
 
 
-def generateReporterId():
+def generate_reporter_id():
     hostname = socket.gethostname()
-    machine_id = getMachineId()
+    machine_id = get_machine_id()
     if not machine_id or len(machine_id) == 0:
         return hostname
     else:


### PR DESCRIPTION
* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1762780
* Validation using _validate_non_empty_string did not have side
  effect of setting default value and debug print also didn't
  print default value