### PR TITLE
1751441: Add command line path parameter

### DIFF
--- a/virtwho/parser.py
+++ b/virtwho/parser.py
@@ -479,9 +479,11 @@ def parse_cli_arguments():
             description="Use these options with --kubevirt"
         )
         kubevirt_group.add_argument("--kubevirt-owner", action=StoreGroupArgument, dest="owner", default="",
-                                 help="[Deprecated] Organization who has purchased subscriptions of the products")
+                                    help="[Deprecated] Organization who has purchased subscriptions of the products")
         kubevirt_group.add_argument("--kubevirt-env", action=StoreGroupArgument, dest="env", default="",
-                                 help="[Deprecated] Environment where Kubevirt belongs to")
+                                    help="[Deprecated] Environment where Kubevirt belongs to")
+        kubevirt_group.add_argument("--kubevirt-cfg", action=StoreGroupArgument, dest="kubeconfig", default="~/.kube/config",
+                                    help="[Deprecated] Path to Kubernetes config file")
 
         ahv_group = parser.add_argument_group(
             title="AHV PC/PE options",


### PR DESCRIPTION
We would like to be able to provide path to kubernetes config file using command line parameter. This PR introduces new `kubevirt-cfg` parameter which can be use to pass the path.