### PR TITLE
1757985: better behavior of virt-who in one shot mode; ENT-1713

### DIFF
--- a/virtwho/config.py
+++ b/virtwho/config.py
@@ -1504,7 +1504,7 @@ def init_config(env_options, cli_options, config_dir=None):
             https = os.environ['https_proxy']
         http = None
         if 'http_proxy' in os.environ:
-            http =  os.environ['http_proxy']
+            http = os.environ['http_proxy']
             del os.environ['http_proxy']
         if http and not https:
             os.environ['https_proxy'] = http

--- a/virtwho/main.py
+++ b/virtwho/main.py
@@ -157,6 +157,20 @@ def main():
             logger.error(err)
             exit(1, err)
 
+    if len(effective_config[VW_GLOBAL]['configs']) > 0:
+        # When config file is provided using -c or --config, then other config
+        # files in /etc/virt-who.d are ignored. When it is not possible to read
+        # any configuration file, then virt-who should be terminated
+        cli_config_file_readable = False
+        for file_name in effective_config[VW_GLOBAL]['configs']:
+            if os.path.isfile(file_name):
+                cli_config_file_readable = True
+
+        if cli_config_file_readable is False:
+            err = 'No valid configuration file provided using -c/--config'
+            logger.error(err)
+            exit(1, "virt-who can't be started: %s" % str(err))
+
     for name, config in executor.dest_to_source_mapper.configs:
         logger.info('Using configuration "%s" ("%s" mode)', name,
                     config['type'])


### PR DESCRIPTION
* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1757985
* When virt-who is started in one shot mode (option -o) and
  configuration file(s) are provided using -c option(s), then
  at least one configuration file should be valid