### PR TITLE
1775535: config option to override api version

### DIFF
--- a/template.conf
+++ b/template.conf
@@ -16,6 +16,7 @@
 #owner=              ; owner for use with SAM, Customer Portal, or Satellite 6
 #hypervisor_id=      ; how will be the hypervisor identified, one of: uuid, hostname, hwuuid
 #kubeconfig=         : path to kubernetes configuration file - kubevirt specific option
+#kubeversion=        : used to override kubevirt api version - kubevirt specific option
 
 ## For complete list of options, see virt-who-config(5) manual page.
 
@@ -37,3 +38,4 @@
 #
 ## Configuring virt-who to connect to Kubevirt
 #kubeconfig=
+#kubeversion=

--- a/tests/test_kubevirt.py
+++ b/tests/test_kubevirt.py
@@ -169,3 +169,26 @@ class TestKubevirt(TestBase):
 
         kubevirt = Virt.from_config(self.logger, config, Datastore())
         self.assertEqual("~/.kube/config", kubevirt._path)
+
+    @patch("virtwho.virt.kubevirt.config._get_kube_config_loader_for_yaml_file",
+           return_value=Mock())
+    @patch("virtwho.virt.kubevirt.config.Configuration")
+    def test_version_override(self, cfg, _):
+        version='v1alpha3'
+        cfg.return_value = Config()
+        config = self.create_config(name='test', wrapper=None, type='kubevirt',
+                                    owner='owner', kubeconfig='/etc/hosts',
+                                    kubeversion=version, hypervisor_id='hostname')
+
+        kubevirt = Virt.from_config(self.logger, config, Datastore())
+        kubevirt.prepare()
+        self.assertEqual(version, kubevirt._version)
+
+
+class Config(object):
+
+    ssl_ca_cert = "file"
+    cert_file = "file"
+    key_file = "file"
+    host = "localhost"
+    token = "token"

--- a/virt-who-config.5
+++ b/virt-who-config.5
@@ -137,6 +137,9 @@ Property that should be used as identification of the hypervisor. Can be one of 
 .TP
 \fB#kubeconfig\fR
 Path to Kubernetes configuration file which contains authentication and connection details. Used by kubevirt option
+.TP
+\fB#kubeversion\fR
+API version used to override kubevirt api version fetched from the cluster. Used by kubevirt option
 
 .SH EXAMPLE
 [test-esx]

--- a/virtwho/parser.py
+++ b/virtwho/parser.py
@@ -43,7 +43,7 @@ SAT5_VM_DISPATCHER = {
     'xen': {'owner': False, 'server': True, 'username': True},
     'rhevm': {'owner': False, 'server': True, 'username': True},
     'hyperv': {'owner': False, 'server': True, 'username': True},
-    'kubevirt': {'owner': False, 'server': False, 'username': False, 'kubeconfig': True},
+    'kubevirt': {'owner': False, 'server': False, 'username': False, 'kubeconfig': True, 'kubeversion': False},
     'ahv' : {'owner': False, 'server': False, 'username': False},
 }
 
@@ -53,7 +53,7 @@ SAT6_VM_DISPATCHER = {
     'xen': {'owner': True, 'server': True, 'username': True},
     'rhevm': {'owner': True, 'server': True, 'username': True},
     'hyperv': {'owner': True, 'server': True, 'username': True},
-    'kubevirt': {'owner': True, 'server': False, 'username': False, 'kubeconfig': True},
+    'kubevirt': {'owner': True, 'server': False, 'username': False, 'kubeconfig': True, 'kubeversion': False},
     'ahv' : {'owner': False, 'server': False, 'username': False},
 }
 

--- a/virtwho/virt/kubevirt/client.py
+++ b/virtwho/virt/kubevirt/client.py
@@ -33,7 +33,7 @@ _TIMEOUT = 60
 
 class KubeClient:
 
-    def __init__(self, path):
+    def __init__(self, path, version):
         cfg = config.Configuration()
         cl = config._get_kube_config_loader_for_yaml_file(path)
         cl.load_and_set(cfg)
@@ -54,7 +54,10 @@ class KubeClient:
 
         self.host = cfg.host
         self.token = cfg.token
-        self._version = self._kubevirt_version()
+        if not version:
+            self._version = self._kubevirt_version()
+        else:
+            self._version = version
 
     def get_nodes(self):
         return self._request('/api/v1/nodes')


### PR DESCRIPTION
There is non trivial bug in kubevirt where preferred api version call returns wrong version. In this PR we provide a way to override version so virt-who can work with broken clusters.