### PR TITLE
1806572: virt-who using V3 APIs for communication with RHEVM which is…

### DIFF
--- a/tests/test_rhevm.py
+++ b/tests/test_rhevm.py
@@ -128,11 +128,11 @@ class TestRhevM(TestBase):
 
         self.assertEqual(get.call_count, 3)
         get.assert_has_calls([
-            call('https://localhost:8443/api/clusters', auth=ANY, verify=ANY),
+            call('https://localhost:8443/ovirt-engine/api/clusters', auth=ANY, verify=ANY, headers=ANY),
             call().raise_for_status(),
-            call('https://localhost:8443/api/hosts', auth=ANY, verify=ANY),
+            call('https://localhost:8443/ovirt-engine/api/hosts', auth=ANY, verify=ANY, headers=ANY),
             call().raise_for_status(),
-            call('https://localhost:8443/api/vms', auth=ANY, verify=ANY),
+            call('https://localhost:8443/ovirt-engine/api/vms', auth=ANY, verify=ANY, headers=ANY),
             call().raise_for_status(),
         ])
         self.assertEqual(get.call_args[1]['auth'].username, u'username'.encode('utf-8'))


### PR DESCRIPTION
… deprecated

The header of Version:3 will still need to be used with a v4 instance.
The url ending of 'ovirt-engine/api' [v4] will be tried before
'api' [older v3] as a fallback.