### PR TITLE
1806572: RHEVM should only use version 4

### DIFF
--- a/tests/complex/data/rhevm/rhevm_hosts.xml
+++ b/tests/complex/data/rhevm/rhevm_hosts.xml
@@ -35,7 +35,13 @@
         <spm>
             <priority>5</priority>
         </spm>
-        <version major="4" minor="16" build="8" revision="1" full_version="vdsm-4.16.8.1-5.el6ev"/>
+        <version>
+            <major>4</major>
+            <minor>16</minor>
+            <build>8</build>
+            <revision>1</revision>
+            <full_version>vdsm-4.16.8.1-5.el6ev</full_version>
+        </version>
         <hardware_information>
             <manufacturer>IBM</manufacturer>
             <version>00</version>
@@ -85,7 +91,11 @@
             <fingerprint>ae:57:8c:12:fa:3b:ba:52:ea:f1:d5:b3:fa:fd:8b:0a</fingerprint>
         </ssh>
         <cpu>
-            <topology sockets="1" cores="6" threads="2"/>
+            <topology>
+                <sockets>1</sockets>
+                <cores>6</cores>
+                <threads>2</threads>
+            </topology>
             <name>Intel(R) Xeon(R) CPU           E5649  @ 2.53GHz</name>
             <speed>2527</speed>
         </cpu>
@@ -145,7 +155,13 @@
         <spm>
             <priority>5</priority>
         </spm>
-        <version major="4" minor="14" build="13" revision="0" full_version="vdsm-4.14.13-3.bz1152587v2.el6ev"/>
+        <version>
+            <major>4</major>
+            <minor>14</minor>
+            <build>13</build>
+            <revision>0</revision>
+            <full_version>vdsm-4.14.13-3.bz1152587v2.el6ev</full_version>
+        </version>
         <hardware_information>
             <manufacturer>IBM</manufacturer>
             <serial_number>99FC371</serial_number>
@@ -175,7 +191,11 @@
             <fingerprint>41:51:c4:92:fe:78:6f:e2:ce:d6:5f:1c:98:2f:09:81</fingerprint>
         </ssh>
         <cpu>
-            <topology sockets="1" cores="4" threads="1"/>
+            <topology>
+                <sockets>1</sockets>
+                <cores>4</cores>
+                <threads>1</threads>
+            </topology>
             <name>Intel(R) Xeon(R) CPU           E5420  @ 2.50GHz</name>
             <speed>2490</speed>
         </cpu>
@@ -232,7 +252,13 @@
         <spm>
             <priority>5</priority>
         </spm>
-        <version major="4" minor="16" build="8" revision="1" full_version="vdsm-4.16.8.1-6.el6ev"/>
+        <version>
+            <major>4</major>
+            <minor>16</minor>
+            <build>8</build>
+            <revision>1</revision>
+            <full_version>vdsm-4.16.8.1-6.el6ev</full_version>
+        </version>
         <hardware_information>
             <manufacturer>IBM</manufacturer>
             <version>00</version>
@@ -282,7 +308,11 @@
             <fingerprint>6f:36:76:a7:08:66:3b:5f:66:3b:20:b5:21:04:bc:cf</fingerprint>
         </ssh>
         <cpu>
-            <topology sockets="1" cores="6" threads="2"/>
+            <topology>
+                <sockets>1</sockets>
+                <cores>6</cores>
+                <threads>2</threads>
+            </topology>
             <name>Intel(R) Xeon(R) CPU           E5649  @ 2.53GHz</name>
             <speed>2533</speed>
         </cpu>
@@ -341,7 +371,13 @@
         <spm>
             <priority>5</priority>
         </spm>
-        <version major="4" minor="16" build="8" revision="1" full_version="vdsm-4.16.8.1-6.el6ev"/>
+        <version>
+            <major>4</major>
+            <minor>16</minor>
+            <build>8</build>
+            <revision>1</revision>
+            <full_version>vdsm-4.16.8.1-6.el6ev</full_version>
+        </version>
         <hardware_information>
             <manufacturer>IBM</manufacturer>
             <version>00</version>
@@ -391,7 +427,11 @@
             <fingerprint>6f:36:76:a7:08:66:3b:5f:66:3b:20:b5:21:04:bc:cf</fingerprint>
         </ssh>
         <cpu>
-            <topology sockets="1" cores="6" threads="2"/>
+            <topology>
+                <sockets>1</sockets>
+                <cores>6</cores>
+                <threads>2</threads>
+            </topology>
             <name>Intel(R) Xeon(R) CPU           E5649  @ 2.53GHz</name>
             <speed>2533</speed>
         </cpu>

--- a/tests/complex/fake_rhevm4.py
+++ b/tests/complex/fake_rhevm4.py
@@ -33,21 +33,14 @@ class Rhevm4Handler(FakeHandler):
         if self.path == '/ovirt-engine/api':
             self.write_file('rhevm', 'rhev4_api.xml')
         elif self.path == '/ovirt-engine/api/clusters':
-            self.check_version_header()
             self.write_file('rhevm', 'rhevm_clusters.xml')
         elif self.path == '/ovirt-engine/api/hosts':
-            self.check_version_header()
             self.write_file('rhevm', 'rhevm_hosts.xml')
         elif self.path == '/ovirt-engine/api/vms':
-            self.check_version_header()
             self.write_file('rhevm', 'rhevm_vms_%d.xml' % self.server._data_version.value)
         else:
             self.send_response(404)
             self.end_headers()
-
-    def check_version_header(self):
-        if not self.headers['Version'] == '3':
-            self.send_response(400, 'Version header mismatch')
 
 
 class FakeRhevm4(FakeVirt):

--- a/tests/test_rhevm.py
+++ b/tests/test_rhevm.py
@@ -59,9 +59,15 @@ HOSTS_XML = '''<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
         <address>hostname.domainname</address>
         <cluster href="/api/clusters/{cluster}" id="{cluster}"/>
         <cpu>
-            <topology sockets="1" cores="6" threads="2"/>
+            <topology>
+                <sockets>1</sockets>
+                <cores>6</cores>
+                <threads>2</threads>
+            </topology>
         </cpu>
-        <version full_version="1.2.3" />
+        <version>
+            <full_version>1.2.3</full_version>
+        </version>
         <hardware_information>
             <uuid>db5a7a9f-6e33-3bfd-8129-c8010e4e1497</uuid>
         </hardware_information>
@@ -108,7 +114,6 @@ class TestRhevM(TestBase):
         config = self.create_config(name='test', wrapper=None, type='rhevm', server='localhost', username='username',
                         password=u'1€345678', owner='owner')
         self.rhevm = Virt.from_config(self.logger, config, Datastore())
-        self.rhevm.major_version = '3'
         self.rhevm.build_urls()
 
     def run_once(self, queue=None):
@@ -128,11 +133,11 @@ class TestRhevM(TestBase):
 
         self.assertEqual(get.call_count, 3)
         get.assert_has_calls([
-            call('https://localhost:8443/ovirt-engine/api/clusters', auth=ANY, verify=ANY, headers=ANY),
+            call('https://localhost:8443/ovirt-engine/api/clusters', auth=ANY, verify=ANY),
             call().raise_for_status(),
-            call('https://localhost:8443/ovirt-engine/api/hosts', auth=ANY, verify=ANY, headers=ANY),
+            call('https://localhost:8443/ovirt-engine/api/hosts', auth=ANY, verify=ANY),
             call().raise_for_status(),
-            call('https://localhost:8443/ovirt-engine/api/vms', auth=ANY, verify=ANY, headers=ANY),
+            call('https://localhost:8443/ovirt-engine/api/vms', auth=ANY, verify=ANY),
             call().raise_for_status(),
         ])
         self.assertEqual(get.call_args[1]['auth'].username, u'username'.encode('utf-8'))


### PR DESCRIPTION
RHEVM version 3 is EOL. Only version 4 needs to be used.