### PR TITLE
1806572: RHEVM API url needs version specified

### DIFF
--- a/tests/complex/fake_rhevm4.py
+++ b/tests/complex/fake_rhevm4.py
@@ -30,13 +30,13 @@ class Rhevm4Handler(FakeHandler):
         time.sleep(0.1)
         print(("[RHEVM] DO GET", self.path))
 
-        if self.path == '/ovirt-engine/api':
+        if self.path == '/ovirt-engine/api/v4':
             self.write_file('rhevm', 'rhev4_api.xml')
-        elif self.path == '/ovirt-engine/api/clusters':
+        elif self.path == '/ovirt-engine/api/v4/clusters':
             self.write_file('rhevm', 'rhevm_clusters.xml')
-        elif self.path == '/ovirt-engine/api/hosts':
+        elif self.path == '/ovirt-engine/api/v4/hosts':
             self.write_file('rhevm', 'rhevm_hosts.xml')
-        elif self.path == '/ovirt-engine/api/vms':
+        elif self.path == '/ovirt-engine/api/v4/vms':
             self.write_file('rhevm', 'rhevm_vms_%d.xml' % self.server._data_version.value)
         else:
             self.send_response(404)

--- a/tests/test_rhevm.py
+++ b/tests/test_rhevm.py
@@ -133,11 +133,11 @@ class TestRhevM(TestBase):
 
         self.assertEqual(get.call_count, 3)
         get.assert_has_calls([
-            call('https://localhost:8443/ovirt-engine/api/clusters', auth=ANY, verify=ANY),
+            call('https://localhost:8443/ovirt-engine/api/v4/clusters', auth=ANY, verify=ANY),
             call().raise_for_status(),
-            call('https://localhost:8443/ovirt-engine/api/hosts', auth=ANY, verify=ANY),
+            call('https://localhost:8443/ovirt-engine/api/v4/hosts', auth=ANY, verify=ANY),
             call().raise_for_status(),
-            call('https://localhost:8443/ovirt-engine/api/vms', auth=ANY, verify=ANY),
+            call('https://localhost:8443/ovirt-engine/api/v4/vms', auth=ANY, verify=ANY),
             call().raise_for_status(),
         ])
         self.assertEqual(get.call_args[1]['auth'].username, u'username'.encode('utf-8'))

--- a/virtwho/virt/rhevm/rhevm.py
+++ b/virtwho/virt/rhevm/rhevm.py
@@ -111,7 +111,7 @@ class RhevM(virt.Virt):
                                     interval=interval,
                                     oneshot=oneshot)
         self.url = self.config['server']
-        self.api_base = 'ovirt-engine/api'
+        self.api_base = 'ovirt-engine/api/v4'
         self.username = self.config['username']
         self.password = self.config['password']
         self.auth = HTTPBasicAuth(self.username.encode('utf-8'), self.password.encode('utf-8'))


### PR DESCRIPTION
Despite the call to a version 4 RHEVM plaform, the system
 uses the version three of the api unless it is specifically
 set to use version 4.