### PR TITLE
184506: virt-who should send its version in the User-Agent header

### DIFF
--- a/virtwho/manager/subscriptionmanager/subscriptionmanager.py
+++ b/virtwho/manager/subscriptionmanager/subscriptionmanager.py
@@ -1,5 +1,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import print_function
+
+from virtwho import parser
+
 """
 Module for communication with subscription-manager, part of virt-who
 
@@ -158,6 +161,8 @@ class SubscriptionManager(Manager):
             kwargs['correlation_id'] = self.correlation_id
 
         self.connection = rhsm_connection.UEPConnection(**kwargs)
+        # add version to user_agent header on connection BZ 1844506
+        self.connection.conn.user_agent += " " + parser.get_version().replace(" ","/")
         try:
             if not self.connection.ping()['result']:
                 raise SubscriptionManagerError(


### PR DESCRIPTION
My attempts to create a unit test were not successful. I stopped in the interest of time.

The way to test this is to run candlepin with debug logging and see the user-agent header there.