### PR TITLE
1876927: virt-who fails to parse output from hypervisor

### DIFF
--- a/tests/test_esx.py
+++ b/tests/test_esx.py
@@ -314,6 +314,64 @@ class TestEsx(TestBase):
         result = self.esx.getHostGuestMapping()['hypervisors'][0]
         self.assertEqual(expected_result.toDict(), result.toDict())
 
+
+    @patch('suds.client.Client')
+    def test_getHostGuestMapping_cluster_slash(self, mock_client):
+        expected_hostname = 'hostname.domainname'
+        expected_hypervisorId = 'Fake_uuid'
+        expected_guestId = 'guest1UUID'
+        expected_guest_state = Guest.STATE_RUNNING
+
+        fake_parent = MagicMock()
+        fake_parent.value = 'fake_parent_id'
+        fake_parent._type = 'ClusterComputeResource'
+
+        fake_vm_id = MagicMock()
+        fake_vm_id.value = 'guest1'
+
+        fake_vm = MagicMock()
+        fake_vm.ManagedObjectReference = [fake_vm_id]
+        fake_vms = {'guest1': {'runtime.powerState': 'poweredOn',
+                               'config.uuid': expected_guestId}}
+        self.esx.vms = fake_vms
+
+        fake_host = {'hardware.systemInfo.uuid': expected_hypervisorId,
+                     'config.network.dnsConfig.hostName': 'hostname',
+                     'config.network.dnsConfig.domainName': 'domainname',
+                     'config.product.version': '1.2.3',
+                     'hardware.cpuInfo.numCpuPackages': '1',
+                     'name': expected_hostname,
+                     'parent': fake_parent,
+                     'vm': fake_vm,
+                     }
+        fake_hosts = {'random-host-id': fake_host}
+        self.esx.hosts = fake_hosts
+
+        fake_cluster = {'name': 'FOO-BAR Dev%2fTest Cluster'}
+        self.esx.clusters = {'fake_parent_id': fake_cluster}
+
+        expected_result = Hypervisor(
+            hypervisorId=expected_hypervisorId,
+            name=expected_hostname,
+            guestIds=[
+                Guest(
+                    expected_guestId,
+                    self.esx.CONFIG_TYPE,
+                    expected_guest_state,
+                )
+            ],
+            facts={
+                Hypervisor.CPU_SOCKET_FACT: '1',
+                Hypervisor.HYPERVISOR_TYPE_FACT: 'vmware',
+                Hypervisor.HYPERVISOR_VERSION_FACT: '1.2.3',
+                Hypervisor.HYPERVISOR_CLUSTER: 'FOO-BAR Dev/Test Cluster',
+                Hypervisor.SYSTEM_UUID_FACT: expected_hypervisorId
+            }
+        )
+        result = self.esx.getHostGuestMapping()['hypervisors'][0]
+        self.assertEqual(expected_result.toDict(), result.toDict())
+
+
     @patch('suds.client.Client')
     def test_oneshot(self, mock_client):
         expected_assoc = '"well formed HostGuestMapping"'

--- a/virtwho/virt/esx/esx.py
+++ b/virtwho/virt/esx/esx.py
@@ -40,6 +40,11 @@ from six.moves.http_client import HTTPException
 from virtwho import virt
 from virtwho.config import VirtConfigSection
 
+try:
+    from urllib.parse import unquote as urldecode
+except ImportError:
+    from urllib import unquote as urldecode
+
 
 class FileAdapter(requests.adapters.BaseAdapter):
     '''Add handler from downloading local files.
@@ -298,7 +303,7 @@ class Esx(virt.Virt):
                 cluster_id = host['parent'].value
                 # print('', self.clusters, cluster_id)
                 cluster = self.clusters[cluster_id]
-                facts[virt.Hypervisor.HYPERVISOR_CLUSTER] = cluster['name']
+                facts[virt.Hypervisor.HYPERVISOR_CLUSTER] = urldecode(cluster['name'])
 
             version = host.get('config.product.version', None)
             if version:


### PR DESCRIPTION
The cluster name in vCenter allows characters that require
 URL encoding. Because of this, that value needs to be URL
 decoded before the data can be used.