### PR TITLE
1855550: [Remote Libvirt] The Name in Stage Candlepin cannot update b…

### DIFF
--- a/tests/test_libvirtd.py
+++ b/tests/test_libvirtd.py
@@ -137,10 +137,11 @@ class TestLibvirtd(TestBase):
         virt.return_value.getCapabilities.return_value = LIBVIRT_CAPABILITIES_XML
         virt.return_value.getType.return_value = "LIBVIRT_TYPE"
         virt.return_value.getVersion.return_value = "VERSION 1337"
+        virt.return_value.getHostname.return_value = "test_host"
         self.run_virt(config, datastore)
         result = datastore.get(config.name)
         for host in result.association['hypervisors']:
-            self.assertTrue(host.name is not None)
+            self.assertTrue(host.name == "test_host")
 
     @patch('libvirt.openReadOnly')
     def test_mapping_hypervisor_has_system_uuid(self, virt):
@@ -161,6 +162,7 @@ class TestLibvirtd(TestBase):
         virt.return_value.getCapabilities.return_value = LIBVIRT_CAPABILITIES_NO_HOSTNAME_XML
         virt.return_value.getType.return_value = "LIBVIRT_TYPE"
         virt.return_value.getVersion.return_value = "VERSION 1337"
+        virt.return_value.getHostname.return_value = None
         self.run_virt(config, datastore)
         result = datastore.get(config.name)
         for host in result.association['hypervisors']:

--- a/virtwho/virt/libvirtd/libvirtd.py
+++ b/virtwho/virt/libvirtd/libvirtd.py
@@ -411,7 +411,7 @@ class Libvirtd(Virt):
     def _remote_host_name(self):
         if self._host_name is None:
             try:
-                self._host_name = self.host_capabilities_xml.find('host/name').text
+                self._host_name = self.virt.getHostname()
             except AttributeError:
                 self._host_name = None
         return self._host_name


### PR DESCRIPTION
…ased on hypervisor_id configuration

    The hostname was not collected correctly in the remote libvirt scenario for the name field.
    Katello uses the hypervisor id on creation as a fallback for this field which is
    then stored in Katello. It does not use this fallback method on updates, so a change in
    hypervisor_id does not show in Katello. This fix remedies the original
    problem where the hostname was not assigned to the name field in the hypervisor report.
