### PR TITLE
1922945: Fixing a possible typo in applyClusterComputeResource

### DIFF
--- a/virtwho/virt/esx/esx.py
+++ b/virtwho/virt/esx/esx.py
@@ -440,7 +440,7 @@ class Esx(virt.Virt):
                     self.applyClusterComputeResource(objectSet)
 
     def applyClusterComputeResource(self, objectSet):
-        if objectSet.kind in ['enter', 'kind']:
+        if objectSet.kind in ['enter', 'modify']:
             cluster = self.clusters[objectSet.obj.value]
             for change in objectSet.changeSet:
                 if change.op == 'assign' and hasattr(change, 'val'):


### PR DESCRIPTION
I do believe that there is a typo in the line I want to fix. Have been having hard time to find any possible documentation about these events/kinds. I would appreciate any links to them. However, looking at other similar calls like: applyVirtualMachineUpdate and applyHostSystemUpdate, I assume that 'kind' was a typo and it should be 'modify'. Definitely need someone who knows what's going on to have a look into this. 