### PR TITLE
Status execution

### DIFF
--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -66,7 +66,8 @@ class TestLog(TestBase):
                 'background': True,
                 'log_file': log.DEFAULT_LOG_FILE,
                 'log_dir': log.DEFAULT_LOG_DIR,
-                'log_per_config': False
+                'log_per_config': False,
+                'status': False
             }
         }
         config = StubEffectiveConfig(conf_values)
@@ -94,6 +95,7 @@ class TestLog(TestBase):
                 'log_per_config': True,
                 'log_dir': '/test/',
                 'log_file': 'test.log',
+                'status': False
             },
         }
         log.init(options)

--- a/tests/test_virt.py
+++ b/tests/test_virt.py
@@ -7,16 +7,16 @@ import shutil
 from base import TestBase
 from stubs import StubEffectiveConfig
 
-from mock import Mock, patch, call
+from mock import Mock, patch, call, ANY
 from threading import Event
 
 from virtwho import MinimumJobPollInterval
 from virtwho.config import DestinationToSourceMapper, VW_GLOBAL, EffectiveConfig, parse_file, \
     VirtConfigSection
-from virtwho.manager import ManagerThrottleError
+from virtwho.datastore import Datastore
+from virtwho.manager import ManagerThrottleError, ManagerError
 from virtwho.virt import HostGuestAssociationReport, Hypervisor, Guest, \
-    DestinationThread, ErrorReport, AbstractVirtReport, DomainListReport
-
+    DestinationThread, ErrorReport, AbstractVirtReport, DomainListReport, Virt, VirtError, StatusReport
 
 xvirt = type("", (), {'CONFIG_TYPE': 'xxx'})()
 
@@ -112,6 +112,40 @@ owner=owner
             ]
         }
 
+class TestVirtStatus(TestBase):
+
+    def test_status_error(self):
+        config_values = {
+            'type': 'virt',
+            'server': 'localhost',
+            'username': 'username',
+            'password': 'password',
+            'owner': 'owner',
+        }
+        config = VirtConfigSection('test', None)
+        config.update(**config_values)
+        self.virt = Virt(self.logger, config, None, interval=60)  #  No dest given here
+        self.virt.status = True
+        self.virt._send_data = Mock()
+        self.virt._run=Mock(side_effect=VirtError('unable to connect to source'))
+        self.run_once()
+
+        self.virt._send_data.assert_called_once_with(data_to_send=ANY)
+        self.assertTrue(isinstance(self.virt._send_data.mock_calls[0].kwargs['data_to_send'], StatusReport))
+        self.assertEqual(self.virt._send_data.mock_calls[0].kwargs['data_to_send'].data['source']['message'],
+                             'unable to connect to source.')
+
+    def run_once(self, datastore=None):
+        ''' Run generic virt in oneshot mode '''
+        self.virt._oneshot = True
+        if datastore is None:
+            datastore = Mock(spec=Datastore())
+
+        self.virt.dest = datastore
+        self.virt._terminate_event = Event()
+        self.virt._oneshot = True
+        self.virt._interval = 0
+        self.virt.run()
 
 class TestDestinationThread(TestBase):
 
@@ -314,6 +348,99 @@ class TestDestinationThread(TestBase):
                                                terminate_event=terminate_event,
                                                oneshot=True, options=self.options)
         destination_thread._send_data(data_to_send)
+
+    def test_send_check_status_heartbeat_call(self):
+        # This tests that reports of the right type are batched into one
+        # and that the hypervisorCheckIn method of the destination is called
+        # with the right parameters
+        config1, d1 = self.create_fake_config('source1', **self.default_config_args)
+        config2, d2 = self.create_fake_config('source2', **self.default_config_args)
+        virt1 = Mock()
+        virt1.CONFIG_TYPE = 'esx'
+        virt2 = Mock()
+        virt2.CONFIG_TYPE = 'esx'
+        report1 = StatusReport(config1)
+        report2 = StatusReport(config2)
+
+        data_to_send = {'source1': report1,
+                        'source2': report2}
+
+        source_keys = ['source1', 'source2']
+        report1 = Mock()
+        report2 = Mock()
+        report1.hash = "report1_hash"
+        report2.hash = "report2_hash"
+        datastore = {'source1': report1, 'source2': report2}
+
+        manager = Mock()
+        options = Mock()
+        options.print_ = False
+
+        def check_status(report, options=None):
+            self.assertTrue(isinstance(report, StatusReport))
+            self.assertEqual(options['reporter_id'], 'status_test')
+
+        manager.hypervisorHeartbeat = Mock(side_effect=check_status)
+        manager.hypervisorCheckIn = Mock()
+        logger = Mock()
+        config, d = self.create_fake_config('test', **self.default_config_args)
+        terminate_event = Mock()
+        interval = 10  # Arbitrary for this test
+        destination_thread = DestinationThread(logger, config,
+                                               source_keys=source_keys,
+                                               source=datastore,
+                                               dest=manager,
+                                               interval=interval,
+                                               terminate_event=terminate_event,
+                                               oneshot=True, status=True,
+                                               options=self.options)
+        destination_thread._send_data(data_to_send)
+
+    def test_send_check_status_heartbeat_call_failure(self):
+        # This tests that reports of the right type are batched into one
+        # and that the hypervisorCheckIn method of the destination is called
+        # with the right parameters
+        config1, d1 = self.create_fake_config('source1', **self.default_config_args)
+        config2, d2 = self.create_fake_config('source2', **self.default_config_args)
+        virt1 = Mock()
+        virt1.CONFIG_TYPE = 'esx'
+        virt2 = Mock()
+        virt2.CONFIG_TYPE = 'esx'
+        report1 = StatusReport(config1)
+        report2 = StatusReport(config2)
+
+        data_to_send = {'source1': report1,
+                        'source2': report2}
+
+        source_keys = ['source1', 'source2']
+        report1 = Mock()
+        report2 = Mock()
+        report1.hash = "report1_hash"
+        report2.hash = "report2_hash"
+        datastore = {'source1': report1, 'source2': report2}
+
+        manager = Mock()
+        options = Mock()
+        options.print_ = False
+
+        manager.hypervisorHeartbeat = Mock(side_effect=ManagerError("cannot connect to destination"))
+        manager.hypervisorCheckIn = Mock()
+        logger = Mock()
+        config, d = self.create_fake_config('test', **self.default_config_args)
+        config.owner = 'test_owner'
+        terminate_event = Mock()
+        interval = 10  # Arbitrary for this test
+        destination_thread = DestinationThread(logger, config,
+                                               source_keys=source_keys,
+                                               source=datastore,
+                                               dest=manager,
+                                               interval=interval,
+                                               terminate_event=terminate_event,
+                                               oneshot=True, status=True,
+                                               options=self.options)
+        destination_thread._send_data(data_to_send)
+        for source_key, report in data_to_send.items():
+            self.assertEqual(report.data['destination']['message'], "cannot connect to destination.")
 
     def test_send_data_poll_hypervisor_async_result(self):
         # This test's that when we have an async result from the server,

--- a/tests/test_virt_intervalthread.py
+++ b/tests/test_virt_intervalthread.py
@@ -86,7 +86,7 @@ class TestIntervalThreadTiming(TestBase):
             interval_thread.wait = Mock()
             interval_thread._run()
             interval_thread._get_data.assert_called()
-            interval_thread._send_data.assert_has_calls([call(self._get_data_return)])
+            interval_thread._send_data.assert_has_calls([call(data_to_send=self._get_data_return)])
             interval_thread.wait.assert_has_calls([call(expected_wait_time)])
 
     def test__run_send_takes_longer_than_interval(self):
@@ -109,7 +109,7 @@ class TestIntervalThreadTiming(TestBase):
             interval_thread.wait = Mock()
             interval_thread._run()
             interval_thread._get_data.assert_called()
-            interval_thread._send_data.assert_has_calls([call(self._get_data_return)])
+            interval_thread._send_data.assert_has_calls([call(data_to_send=self._get_data_return)])
             interval_thread.wait.assert_not_called()
 
 

--- a/virtwho/config.py
+++ b/virtwho/config.py
@@ -1246,6 +1246,8 @@ class GlobalSection(ConfigSection):
         super(GlobalSection, self).__init__(*args, **kwargs)
         self.add_key('debug', validation_method=self._validate_str_to_bool, default=False)
         self.add_key('oneshot', validation_method=self._validate_str_to_bool, default=False)
+        self.add_key('status', validation_method=self._validate_str_to_bool, default=False)
+        self.add_key('json', validation_method=self._validate_str_to_bool, default=False)
         self.add_key('print_', validation_method=self._validate_str_to_bool, default=False, destination='print')
         self.add_key('log_per_config', validation_method=self._validate_str_to_bool, default=False)
         self.add_key('configs', validation_method=self._validate_list, default=[])

--- a/virtwho/log.py
+++ b/virtwho/log.py
@@ -173,9 +173,10 @@ class Logger(object):
     _level = logging.DEBUG
     _rhsm_level = logging.WARN
     _queue_logger = None
+    _status = None
 
     @classmethod
-    def initialize(cls, log_dir=None, log_file=None, log_per_config=None, debug=None):
+    def initialize(cls, log_dir=None, log_file=None, log_per_config=None, debug=None, status=None):
         # Set defaults if necessary
         if log_dir:
             cls._log_dir = log_dir
@@ -186,6 +187,7 @@ class Logger(object):
         cls._level = logging.DEBUG if debug else logging.INFO
         # We don't want INFO message from RHSM in non-debug mode
         cls._rhsm_level = logging.DEBUG if debug else logging.WARN
+        cls._status = status
 
     @classmethod
     def get_logger(cls, name=None, config=None, queue=True):
@@ -222,7 +224,7 @@ class Logger(object):
 
         journal_handler = None
         stream_handler = None
-        if ppid == 1:
+        if ppid == 1 or (cls._status and cls._level != logging.DEBUG):
             # we're running under systemd, log to journal
             journal_handler = cls.get_journal_handler()
         else:
@@ -315,8 +317,9 @@ def init(config):
     log_file = config['global']['log_file']
     log_per_config = config['global']['log_per_config']
     debug = config['global']['debug']
+    status = config['global']['status']
     return Logger.initialize(log_dir=log_dir, log_file=log_file, log_per_config=log_per_config,
-                             debug=debug)
+                             debug=debug, status=status)
 
 
 def getLogger(name=None, config=None, queue=True):

--- a/virtwho/main.py
+++ b/virtwho/main.py
@@ -122,13 +122,6 @@ def main():
         print(str(e), file=sys.stderr)
         exit(1, status="virt-who can't be started: %s" % str(e))
 
-    lock = PIDLock(PIDFILE)
-    if lock.is_locked():
-        msg = "virt-who seems to be already running. If not, remove %s" % \
-              PIDFILE
-        print(msg, file=sys.stderr)
-        exit(1, status=msg)
-
     if not effective_config[VW_GLOBAL].is_valid():
         message = "Required section 'global' is invalid:\n"
         message += "\n".join([msg for (level, msg) in effective_config[VW_GLOBAL].validation_messages])
@@ -150,6 +143,16 @@ def main():
     except (InvalidKeyFile, InvalidPasswordFormat) as e:
         logger.error(str(e))
         exit(1, "virt-who can't be started: %s" % str(e))
+
+    lock = PIDLock(PIDFILE)
+    if not executor.options[VW_GLOBAL]['oneshot'] \
+        and not executor.options[VW_GLOBAL]['status'] \
+        and not executor.options[VW_GLOBAL]['print'] \
+        and lock.is_locked():
+        msg = "virt-who seems to be already running. If not, remove %s" % \
+              PIDFILE
+        print(msg, file=sys.stderr)
+        exit(1, status=msg)
 
     if len(executor.dest_to_source_mapper.dests) == 0:
         if has_error:
@@ -196,7 +199,8 @@ def main():
 
 
 def _main(executor):
-    if executor.options[VW_GLOBAL]['oneshot']:
+    if executor.options[VW_GLOBAL]['oneshot'] or executor.options[VW_GLOBAL]['status']:
+        executor.options[VW_GLOBAL]['oneshot'] = True
         result = executor.run_oneshot()
 
         if executor.options[VW_GLOBAL]['print']:
@@ -222,6 +226,9 @@ def _main(executor):
             print( json.dumps({
                 'hypervisors': hypervisors
             }, indent=4, sort_keys=False))
+        if executor.options[VW_GLOBAL]['status']:
+            print(produce_status_output(result))
+
         return 0
 
     # We'll get here only if we're not in oneshot or print_ mode (which
@@ -232,6 +239,46 @@ def _main(executor):
     executor.run()
 
     return 0
+
+RED = '\033[1;31m'
+GREEN = '\033[1;32m'
+RESET = '\033[0;0m'
+
+def produce_status_output(result):
+        output = ''
+        if not executor.options[VW_GLOBAL]['json']:
+            output += ("+-------------------------------------------+\n")
+            output += ("           Configuration Status\n")
+            output += ("+-------------------------------------------+\n")
+            for config, report in result.items():
+                output += f"Configuration Name: {config}\n"
+                if 'message' in report.data['source'] and len(report.data['source']['message']) > 0:
+                    output += f"Source Status: {RED}{report.data['source']['status_string']}{RESET}\n"
+                else:
+                    output += f"Source Status: {GREEN}{report.data['source']['status_string']}{RESET}\n"
+                if 'message' in report.data['destination'] and len(report.data['destination']['message']) > 0:
+                    output += f"Destination Status: {RED}{report.data['destination']['status_string']}{RESET}\n\n"
+                else:
+                    output += f"Destination Status: {GREEN}{report.data['destination']['status_string']}{RESET}\n\n"
+
+            return output
+        else:
+            json_body = []
+            for config, report in result.items():
+                report_dict = {}
+                report_dict['name'] = config
+                report_dict['source'] = {"connection": report.data['source']['server'],
+                                         "status": report.data['source']['status_string']}
+                if 'message' in report.data['source']:
+                    report_dict['source']['message'] = report.data['source']['message']
+                report_dict['destination'] = {"connection": report.data['destination']['server'],
+                                              "status": report.data['destination']['status_string']}
+                if 'message' in report.data['destination']:
+                    report_dict['destination']['message'] = report.data['destination']['message']
+                json_body.append(report_dict)
+            return json.dumps({
+                'configurations': json_body
+            }, indent=4, sort_keys=False)
 
 
 def exit(code, status=None):

--- a/virtwho/parser.py
+++ b/virtwho/parser.py
@@ -234,7 +234,7 @@ def parse_cli_arguments():
     default options.
     """
     parser = ArgumentParser(
-        usage="virt-who [-d] [-o] [-i INTERVAL] [-p] [-c CONFIGS] [--version]",
+        usage="virt-who [-d] [-o] [-i INTERVAL] [-p] [-c CONFIGS] [-s] [-j] [--version]",
         description="Agent for reporting virtual guest IDs to subscription manager",
         epilog = "virt-who also reads environment variables. They have the same name as "
               "command line arguments but uppercased, with underscore instead of dash "
@@ -245,6 +245,10 @@ def parse_cli_arguments():
                         help="Enable debugging output")
     parser.add_argument("-o", "--one-shot", action="store_true", dest="oneshot", default=False,
                         help="Send the list of guest IDs and exit immediately")
+    parser.add_argument("-s", "--status", action="store_true", dest="status", default=False,
+                        help="Produce a report to show connection health")
+    parser.add_argument("-j", "--json", action="store_true", dest="json", default=False,
+                        help="Used with status option to make output in json")
     parser.add_argument("-i", "--interval", dest="interval", default=NotSetSentinel(),
                         help="Acquire list of virtual guest each N seconds. Send if changes are detected.")
     parser.add_argument("-p", "--print", action="store_true", dest="print_", default=False,
@@ -292,6 +296,14 @@ def parse_options():
     if 'version' in cli_options and cli_options['version']:
         print(get_version())
         exit(os.EX_OK)
+
+    if 'status' in cli_options and ('print' in cli_options or 'oneshot' in cli_options):
+        print("You may not use the --print or --one-shot options with the --status option.")
+        exit(os.EX_USAGE)
+
+    if 'json' in cli_options and 'status' not in cli_options:
+        print("The --json option must only be used with the --status option.")
+        exit(os.EX_USAGE)
 
     # Create the effective config that virt-who will use to run
     effective_config = init_config(cli_options)

--- a/virtwho/virt/__init__.py
+++ b/virtwho/virt/__init__.py
@@ -3,10 +3,11 @@ from __future__ import print_function, absolute_import
 
 
 from .virt import (Virt, VirtError, Guest, AbstractVirtReport, DomainListReport,
-                  HostGuestAssociationReport, ErrorReport,
+                  HostGuestAssociationReport, ErrorReport, StatusReport,
                   Hypervisor, DestinationThread, IntervalThread, info_to_destination_class)
 
 __all__ = ['Virt', 'VirtError', 'Guest', 'AbstractVirtReport',
            'DomainListReport', 'HostGuestAssociationReport',
-           'ErrorReport', 'Hypervisor', 'DestinationThread',
-           'IntervalThread', 'info_to_destination_class']
+           'StatusReport', 'ErrorReport', 'Hypervisor',
+           'DestinationThread', 'IntervalThread',
+           'info_to_destination_class']

--- a/virtwho/virt/esx/esx.py
+++ b/virtwho/virt/esx/esx.py
@@ -39,6 +39,7 @@ from six.moves.http_client import HTTPException
 
 from virtwho import virt
 from virtwho.config import VirtConfigSection
+from virtwho.virt import StatusReport
 
 try:
     from urllib.parse import unquote as urldecode
@@ -119,11 +120,12 @@ class Esx(virt.Virt):
     MAX_WAIT_TIME = 60  # 1 minute
 
     def __init__(self, logger, config, dest, terminate_event=None,
-                 interval=None, oneshot=False):
+                 interval=None, oneshot=False, status=False):
         super(Esx, self).__init__(logger, config, dest,
                                   terminate_event=terminate_event,
                                   interval=interval,
-                                  oneshot=oneshot)
+                                  oneshot=oneshot,
+                                  status=status)
         self.url = self.config['server']
         self.username = self.config['username']
         self.password = self.config['password']
@@ -200,6 +202,10 @@ class Esx(virt.Virt):
                 self._prepare()
                 continue
 
+            if self.status:
+                self._send_data(data_to_send=StatusReport(self.config))
+                break
+
             if updateSet is not None:
                 version = updateSet.version
                 self.applyUpdates(updateSet)
@@ -209,7 +215,7 @@ class Esx(virt.Virt):
 
             if last_version != version or time() > next_update:
                 assoc = self.getHostGuestMapping()
-                self._send_data(virt.HostGuestAssociationReport(self.config, assoc))
+                self._send_data(data_to_send=virt.HostGuestAssociationReport(self.config, assoc))
                 next_update = time() + self.interval
                 last_version = version
 

--- a/virtwho/virt/fakevirt/fakevirt.py
+++ b/virtwho/virt/fakevirt/fakevirt.py
@@ -72,11 +72,12 @@ class FakeVirt(Virt):
     CONFIG_TYPE = 'fake'
 
     def __init__(self, logger, config, dest, terminate_event=None,
-                 interval=None, oneshot=False):
+                 interval=None, oneshot=False, status=False):
         super(FakeVirt, self).__init__(logger, config, dest,
                                        terminate_event=terminate_event,
                                        interval=interval,
-                                       oneshot=oneshot)
+                                       oneshot=oneshot,
+                                       status=status)
         self.logger = logger
         self.config = config
 

--- a/virtwho/virt/hyperv/hyperv.py
+++ b/virtwho/virt/hyperv/hyperv.py
@@ -500,11 +500,12 @@ class HyperV(virt.Virt):
     CONFIG_TYPE = "hyperv"
 
     def __init__(self, logger, config, dest, terminate_event=None,
-                 interval=None, oneshot=False):
+                 interval=None, oneshot=False, status=False):
         super(HyperV, self).__init__(logger, config, dest,
                                      terminate_event=terminate_event,
                                      interval=interval,
-                                     oneshot=oneshot)
+                                     oneshot=oneshot,
+                                     status=status)
         self.url = self.config['url']
         self.username = self.config['username']
         self.password = self.config['password']

--- a/virtwho/virt/kubevirt/kubevirt.py
+++ b/virtwho/virt/kubevirt/kubevirt.py
@@ -84,11 +84,12 @@ class Kubevirt(virt.Virt):
     CONFIG_TYPE = "kubevirt"
 
     def __init__(self, logger, config, dest, terminate_event=None,
-                 interval=None, oneshot=False):
+                 interval=None, oneshot=False, status=False):
         super(Kubevirt, self).__init__(logger, config, dest,
                                        terminate_event=terminate_event,
                                        interval=interval,
-                                       oneshot=oneshot)
+                                       oneshot=oneshot,
+                                       status=status)
         self._path = self.config['kubeconfig']
         self._version = self.config['kubeversion']
         self._insecure = str_to_bool(self.config['insecure'])

--- a/virtwho/virt/rhevm/rhevm.py
+++ b/virtwho/virt/rhevm/rhevm.py
@@ -105,11 +105,12 @@ class RhevM(virt.Virt):
     CONFIG_TYPE = "rhevm"
 
     def __init__(self, logger, config, dest, terminate_event=None,
-                 interval=None, oneshot=False):
+                 interval=None, oneshot=False, status=False):
         super(RhevM, self).__init__(logger, config, dest,
                                     terminate_event=terminate_event,
                                     interval=interval,
-                                    oneshot=oneshot)
+                                    oneshot=oneshot,
+                                    status=status)
         self.url = self.config['server']
         self.api_base = 'ovirt-engine/api/v4'
         self.username = self.config['username']


### PR DESCRIPTION
Use the -s/--status option to run virt who in status mode. It will not generate the normal logging output to the screen.
If you add the -d/--debug option, then the normal logging will return

You will see a summary of the results with just -s. If you add the option -j/--json, then you will see an expanded, json version of the results in more detail.

Note that the integration of the run-time data and the lookup of the job status will be in the next card.

Let me know if you need some config files for smoke testing.