### PR TITLE
1985210: The guest state in mapping should be uniform with other hypervisors [8.5]

### DIFF
--- a/tests/test_ahv.py
+++ b/tests/test_ahv.py
@@ -9,6 +9,7 @@ from six.moves.queue import Queue
 from threading import Event
 
 from virtwho import DefaultInterval
+from virtwho import virt
 from virtwho.datastore import Datastore
 from virtwho.virt.ahv.ahv import AhvConfigSection
 from virtwho.virt import Virt, VirtError, Guest, Hypervisor
@@ -538,7 +539,7 @@ class TestAhv(TestBase):
            cluster_uuid = host['cluster_uuid']
            guests = []
            for guest_vm in host['guest_list']:
-               state = guest_vm['power_state']
+               state = virt.Guest.STATE_RUNNING
                guests.append(Guest(guest_vm['uuid'], self.ahv.CONFIG_TYPE,
                                    state))
 

--- a/virtwho/virt/ahv/ahv.py
+++ b/virtwho/virt/ahv/ahv.py
@@ -119,6 +119,12 @@ class Ahv(virt.Virt):
         for guest_vm in host['guest_list']:
           try:
             state = guest_vm['power_state']
+            if guest_vm['power_state'] == 'on':
+              state = virt.Guest.STATE_RUNNING
+            elif guest_vm['power_state'] == 'off':
+              state = virt.Guest.STATE_SHUTOFF
+            else:
+              state = virt.Guest.STATE_UNKNOWN
           except KeyError:
             self.logger.warning("Guest %s is missing power state. Perhaps they"
                                 " are powered off", guest_vm['uuid'])


### PR DESCRIPTION


1985213: The guest shows wrong active value "0" in mapping when it's running.