### PR TITLE
Make changes to follow Conscious language initiative

### DIFF
--- a/tests/complex/data/rhevm/rhevm_vms_0.xml
+++ b/tests/complex/data/rhevm/rhevm_vms_0.xml
@@ -864,7 +864,7 @@
             <link href="/api/vms/afdb464b-921a-4a38-8a3c-650f057298a0/stop" rel="stop"/>
             <link href="/api/vms/afdb464b-921a-4a38-8a3c-650f057298a0/suspend" rel="suspend"/>
         </actions>
-        <name>kuber_master</name>
+        <name>kuber_main</name>
         <link href="/api/vms/afdb464b-921a-4a38-8a3c-650f057298a0/applications" rel="applications"/>
         <link href="/api/vms/afdb464b-921a-4a38-8a3c-650f057298a0/disks" rel="disks"/>
         <link href="/api/vms/afdb464b-921a-4a38-8a3c-650f057298a0/nics" rel="nics"/>

--- a/tests/complex/data/rhevm/rhevm_vms_1.xml
+++ b/tests/complex/data/rhevm/rhevm_vms_1.xml
@@ -864,7 +864,7 @@
             <link href="/api/vms/afdb464b-921a-4a38-8a3c-650f057298a0/stop" rel="stop"/>
             <link href="/api/vms/afdb464b-921a-4a38-8a3c-650f057298a0/suspend" rel="suspend"/>
         </actions>
-        <name>kuber_master</name>
+        <name>kuber_main</name>
         <link href="/api/vms/afdb464b-921a-4a38-8a3c-650f057298a0/applications" rel="applications"/>
         <link href="/api/vms/afdb464b-921a-4a38-8a3c-650f057298a0/disks" rel="disks"/>
         <link href="/api/vms/afdb464b-921a-4a38-8a3c-650f057298a0/nics" rel="nics"/>

--- a/tests/test_kubevirt.py
+++ b/tests/test_kubevirt.py
@@ -40,7 +40,7 @@ class TestKubevirt(TestBase):
     def nodes(self):
         node = {
             'metadata': {
-                'name': 'master'
+                'name': 'main'
             },
             'status': {
                 'nodeInfo': {
@@ -64,7 +64,7 @@ class TestKubevirt(TestBase):
     def new_nodes(self):
         node = {
             'metadata': {
-                'name': 'master'
+                'name': 'main'
             },
             'status': {
                 'nodeInfo': {
@@ -114,7 +114,7 @@ class TestKubevirt(TestBase):
                 }
             },
             'status': {
-                'nodeName': 'master',
+                'nodeName': 'main',
                 'phase': 'Running',
             }
         }
@@ -172,7 +172,7 @@ class TestKubevirt(TestBase):
 
             expected_result = Hypervisor(
                 hypervisorId='52c01ad890e84b15a1be4be18bd64ecd',
-                name='master',
+                name='main',
                 guestIds=[],
                 facts={
                     Hypervisor.CPU_SOCKET_FACT: '2',
@@ -199,7 +199,7 @@ class TestKubevirt(TestBase):
 
             expected_result = Hypervisor(
                 hypervisorId='52c01ad890e84b15a1be4be18bd64ecd',
-                name='master',
+                name='main',
                 guestIds=[
                     Guest(
                         'f83c5f73-5244-4bd1-90cf-02bac2dda608',
@@ -233,7 +233,7 @@ class TestKubevirt(TestBase):
 
             expected_result = Hypervisor(
                 hypervisorId='minikube',
-                name='master',
+                name='main',
                 guestIds=[
                     Guest(
                         'f83c5f73-5244-4bd1-90cf-02bac2dda608',
@@ -265,7 +265,7 @@ class TestKubevirt(TestBase):
 
             expected_result = Hypervisor(
                 hypervisorId='52c01ad890e84b15a1be4be18bd64ecd',
-                name='master',
+                name='main',
                 guestIds=[
                     Guest(
                         'f83c5f73-5244-4bd1-90cf-02bac2dda608',


### PR DESCRIPTION
* Card ID: ENT-3764

No program code has been affected, only files used for testing purposes.

List of changes:
- tests/test_kubevirt.py: Node names have been changed to 'main'
- tests/complex/data/rhevm/: VM names have been changed to 'kuber_main'

Left unchanged:
- virt-who.spec: This file contains changelog, which is not subject to these changes