### PR TITLE
1889363: Update dependency between libvirtd and virt-who

### DIFF
--- a/virt-who.service
+++ b/virt-who.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Daemon for reporting virtual guest IDs to subscription-manager
 After=libvirtd.service network.target
+Wants=libvirtd-ro.socket
 
 [Service]
 Type=notify


### PR DESCRIPTION
This addition is based on this comment in the BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1889363#c12