### PR TITLE
Only query the VM related taks in AHV hypervisors.

### DIFF
--- a/tests/test_ahv.py
+++ b/tests/test_ahv.py
@@ -27,7 +27,8 @@ PE_SECTION_VALUES = {
     'hypervisor_id': 'uuid',
     'is_hypervisor': True,
     'internal_debug': False,
-    'update_interval': 60
+    'update_interval': 60,
+    'wait_time_in_sec': 900
 }
 
 HOST_UVM_MAP = {

--- a/virtwho/virt/ahv/ahv_interface.py
+++ b/virtwho/virt/ahv/ahv_interface.py
@@ -296,9 +296,13 @@ class AhvInterface(object):
         kwargs['verify'] = kwargs.get('verify', False)
         if 'timeout' not in kwargs:
             kwargs['timeout'] = self._timeout
-        if 'data' not in kwargs:
+        if 'json' in kwargs:
+            kwargs['data'] = json.dumps(kwargs['json'])
+            del kwargs['json']
+        else:
             body = {}
             kwargs['data'] = json.dumps(body)
+
         content_dict = {'content-type': 'application/json'}
         kwargs.setdefault('headers', {})
         kwargs['headers'].update(content_dict)
@@ -364,7 +368,8 @@ class AhvInterface(object):
         # For task return. Use fv2.0 for now. update the url to use v2.0.
         url = self._url[:(self._url).rfind('v')] + 'v2.0' + uri
 
-        res = self._send(method=cmd_method, url=url)
+        body = {"entity_list": [{"entity_type": "kVm"}]}
+        res = self._send(method=cmd_method, url=url, json=body)
         data = res.json()
 
         if is_pc:


### PR DESCRIPTION
This change will only query the VM related tasks from AHV
clusters during continous mode to reduce the laod in returning
the tasks in the AHV task manager. A new wait time flag is also
added to cause delay in querying for the tasks in the continous
mode.