### PR TITLE
Update for deprecation of MutableMapping [1.30]

### DIFF
--- a/virtwho/config.py
+++ b/virtwho/config.py
@@ -499,7 +499,7 @@ class ValidationState(object):
     NEEDS_VALIDATION = 'needs_validation'
 
 
-class ConfigSection(collections.MutableMapping):
+class ConfigSection(collections.abc.MutableMapping):
     """
     This represents a section of configuration for virt-who. The interface that it exposes is
     dictionary like. This object maintains a state attribute. The state shows if the configuration
@@ -889,11 +889,11 @@ class ConfigSection(collections.MutableMapping):
                     ]
         for tracker in trackers:
             if key in tracker:
-                if isinstance(tracker, collections.MutableMapping):
+                if isinstance(tracker, collections.abc.MutableMapping):
                     del tracker[key]
-                elif isinstance(tracker, collections.MutableSequence):
+                elif isinstance(tracker, collections.abc.MutableSequence):
                     tracker.remove(key)
-                elif isinstance(tracker, collections.MutableSet):
+                elif isinstance(tracker, collections.abc.MutableSet):
                     tracker.discard(key)
 
 
@@ -1280,7 +1280,7 @@ DEFAULTS = {
 }
 
 
-class EffectiveConfig(collections.MutableMapping):
+class EffectiveConfig(collections.abc.MutableMapping):
     """
     This object represents the total configuration of virt-who including all global parameters
     and all sections that define a source or destination.

--- a/virtwho/virt/hyperv/hyperv.py
+++ b/virtwho/virt/hyperv/hyperv.py
@@ -404,12 +404,11 @@ class HyperVSoap(object):
     def _Instance(cls, xml_doc):
         def stripNamespace(tag):
             return tag[tag.find("}") + 1:]
-        children = xml_doc.getchildren()
-        if len(children) < 1:
+        if len(xml_doc) < 1:
             return None
-        child = children[0]
+        child = xml_doc[0]
         properties = {}
-        for ch in child.getchildren():
+        for ch in child:
             properties[stripNamespace(ch.tag)] = ch.text
         return properties
 
@@ -422,7 +421,7 @@ class HyperVSoap(object):
         responses = xml_doc.findall("{%(s)s}Body/{%(wsen)s}EnumerateResponse" % self.generator.namespaces)
         if len(responses) < 1:
             raise HyperVException("Wrong reply format")
-        contexts = responses[0].getchildren()
+        contexts = responses[0]
         if len(contexts) < 1:
             raise HyperVException("Wrong reply format")
 
@@ -443,7 +442,7 @@ class HyperVSoap(object):
         uuid = None
         instance = None
 
-        for node in responses[0].getchildren():
+        for node in responses[0]:
             if node.tag == "{%(wsen)s}EnumerationContext" % self.generator.namespaces:
                 uuid = node.text
             elif node.tag == "{%(wsen)s}Items" % self.generator.namespaces:
@@ -477,7 +476,7 @@ class HyperVSoap(object):
             raise HyperVException("Wrong reply format")
         info = {}
         si_namespace = self.generator.si_namespace % {'ns': namespace}
-        for node in responses[0].getchildren():
+        for node in responses[0]:
             if 'SummaryInformation' in node.tag:
                 name = node.find("{%(si)s}Name" % {'si': si_namespace}).text
                 enabledState = node.find("{%(si)s}EnabledState" % {'si': si_namespace}).text


### PR DESCRIPTION
The collections.MutableMapping was deprecated in Python 3.3
and the new collections.abc.MutableMapping should be used.
The old API will is completely removed in Python 3.10.

Also cherry-picked a commit from main to cover another python 3.10 change