### PR TITLE
2000019: Convert non-latin1 username/password to bytes

### DIFF
--- a/virtwho/virt/ahv/ahv_interface.py
+++ b/virtwho/virt/ahv/ahv_interface.py
@@ -35,8 +35,8 @@ class AhvInterface(object):
         self._retry_interval = kwargs.get('retry_interval', 30)
         self._logger = logger
         self._url = url
-        self._user = username
-        self._password = password
+        self._user = username.encode('utf-8')
+        self._password = password.encode('utf-8')
         self._port = port
         self._internal_debug = kwargs.get('internal_debug', False)
         self._create_session(self._user, self._password)


### PR DESCRIPTION
* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2000019
* Card ID: ENT-4307
* The requests package does not allow non latin1 strings to be
  used for authentication. It has to be converted to bytes.
* It wasn't possible to concert username/password directly
  to bytes in Ahv, because username/password setters of Virt
  convert these values to strings
* Added few unit tests for this case