### PR TITLE
2000024: [1.30] Convert non-latin1 username/password to bytes

### DIFF
--- a/tests/test_ahv.py
+++ b/tests/test_ahv.py
@@ -356,6 +356,24 @@ class TestAhvConfigSection(TestBase):
         expected_result = ['Invalid server IP address provided']
         six.assertCountEqual(self, expected_result, result)
 
+    def test_validate_ahv_non_latin_username(self):
+        """
+        Test validation of ahv config. Invalid server IP.
+        """
+        self.init_virt_config_section()
+        self.ahv_config['username'] = 'příšerně žluťoučký kůň'
+        result = self.ahv_config.validate()
+        self.assertEqual(len(result), 0)
+
+    def test_validate_ahv_non_latin_password(self):
+        """
+        Test validation of ahv config. Invalid server IP.
+        """
+        self.init_virt_config_section()
+        self.ahv_config['password'] = 'pěl úděsné ódy'
+        result = self.ahv_config.validate()
+        self.assertEqual(len(result), 0)
+
     def test_validate_ahv_config_missing_username_password(self):
         """
         Test validation of ahv config. Username and password is required.
@@ -394,11 +412,18 @@ class TestAhv(TestBase):
         config.validate()
         return config
 
-    def setUp(self, is_pc=False):
-        config = self.create_config(name='test', wrapper=None, type='ahv',
-                                    server='10.10.10.10', username='username',
-                                    password='password', owner='owner',
-                                    prism_central=is_pc)
+    def setUp(self, is_pc=False, config=None):
+        if config is None:
+            config = self.create_config(
+                name='test',
+                wrapper=None,
+                type='ahv',
+                server='10.10.10.10',
+                username='username',
+                password='password',
+                owner='owner',
+                prism_central=is_pc
+            )
         self.ahv = Virt.from_config(self.logger, config, Datastore(),
                                     interval=DefaultInterval)
 
@@ -454,6 +479,26 @@ class TestAhv(TestBase):
 
         mock_get.return_value.status_code = 403
         self.assertRaises(VirtError, self.run_once)
+
+    def test_non_latin1_username_and_password(self):
+        """
+        When non-latin1 string is used as username or password, then it has
+        to be converted to bytes in AHV interface.
+        """
+        config = self.create_config(
+            name='test',
+            wrapper=None,
+            type='ahv',
+            server='10.10.10.10',
+            username='žluťoučký kůň',
+            password='pěl úděsné ódy',
+            owner='owner',
+            prism_central=True
+        )
+        self.setUp(is_pc=True, config=config)
+        # Test that non latin1 username and password were converted to bytes
+        assert self.ahv._interface._user == b'\xc5\xbelu\xc5\xa5ou\xc4\x8dk\xc3\xbd k\xc5\xaf\xc5\x88'
+        assert self.ahv._interface._password == b'p\xc4\x9bl \xc3\xbad\xc4\x9bsn\xc3\xa9 \xc3\xb3dy'
 
     @patch.object(Session, 'post')
     def test_invalid_login_PC(self, mock_post):

--- a/virtwho/virt/ahv/ahv_interface.py
+++ b/virtwho/virt/ahv/ahv_interface.py
@@ -34,8 +34,8 @@ class AhvInterface(object):
     self._retry_interval = kwargs.get('retry_interval', 30)
     self._logger = logger
     self._url = url
-    self._user = username
-    self._password = password
+    self._user = username.encode('utf-8')
+    self._password = password.encode('utf-8')
     self._port = port
     self._internal_debug = kwargs.get('internal_debug', False)
     self._create_session(self._user, self._password)


### PR DESCRIPTION
* Backport PR for RHEL8.6
* Original PR: #354
  * Commit: 19cae242689129a085c1bd2500da4b285fb79521
* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2000024
* Card ID: ENT-4307
* The requests package does not allow non latin1 strings to be
  used for authentication. It has to be converted to bytes.
* It wasn't possible to concert username/password directly
  to bytes in Ahv, because username/password setters of Virt
  convert these values to strings
* Added few unit tests for this case