### PR TITLE
1985258: Move progress bar to stderr to keep stdout clean

### DIFF
--- a/virtwho/virt/ahv/ahv_interface.py
+++ b/virtwho/virt/ahv/ahv_interface.py
@@ -140,7 +140,7 @@ class AhvInterface(object):
 
     return formatted_data
 
-  def _progressbar(self, it, prefix="", size=60, file=sys.stdout, total=0, is_pc=False):
+  def _progressbar(self, it, prefix="", size=60, file=sys.stderr, total=0, is_pc=False):
     count = total
     cursor = 0
     def show(j):


### PR DESCRIPTION
Stdout is used for redirection to create json for the fake fabric.
The output on the screen will appear the same, but the progress
 bar will not be included in the redirect.