### PR TITLE
1990758: Virt-who always prints YAMLLoadWarning for kubevirt mode

### DIFF
--- a/virtwho/virt/kubevirt/config.py
+++ b/virtwho/virt/kubevirt/config.py
@@ -58,7 +58,7 @@ def _cleanup_temp_files():
 def _get_kube_config_loader_for_yaml_file(filename, **kwargs):
     with open(filename) as f:
         return KubeConfigLoader(
-            config_dict=yaml.load(f),
+            config_dict=yaml.load(f, Loader=yaml.FullLoader),
             config_base_path=os.path.abspath(os.path.dirname(filename)),
             **kwargs)
 


### PR DESCRIPTION
The warning was for a deprecation of the method. Explicitly adding the loader type satisfies the warning.