### PR TITLE
Run complex tests as forked for consistent results [main]

### DIFF
--- a/jenkins/pytest.sh
+++ b/jenkins/pytest.sh
@@ -11,7 +11,8 @@ source env-pytest/bin/activate
 
 pip install -U setuptools
 pip install -r requirements.txt
-pip install -U python-dateutil M2Crypto libvirt-python unittest2 pytest-timeout mock
+pip install -r requirements-test.txt
+pip install -U python-dateutil M2Crypto libvirt-python unittest2 
 
 export PYTHONPATH=.
 py.test --timeout=30 -v

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,8 @@
 [pytest]
 addopts=-v
 testpaths = tests
+
+required_plugins =
+	pytest-randomly
+	pytest-timeout
+	pytest-forked

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,2 +1,6 @@
 mock
 flake8
+pytest
+pytest-randomly
+pytest-timeout
+pytest-forked

--- a/tests/complex/virtwhotest.py
+++ b/tests/complex/virtwhotest.py
@@ -19,6 +19,7 @@ from __future__ import print_function
 #
 
 import os
+import pytest
 import signal
 import sys
 import socket
@@ -270,12 +271,14 @@ class TestBase(TestCase):
         except Empty:
             raise AssertionError("Association was not obtained in %d seconds" % timeout)
 
+    @pytest.mark.forked
     def test_basic(self):
         code, _ = self.run_virtwho(self.arguments + ['-o', '--debug'])
         self.assertEqual(code, 0, "virt-who exited with wrong error code: %s" % code)
         assoc = self.wait_for_assoc()
         self.check_assoc_initial(assoc)
 
+    @pytest.mark.forked
     def test_print(self):
         args = self.arguments + ['-p', '--debug']
         code, out = self.run_virtwho(args, grab_stdout=True)
@@ -321,6 +324,7 @@ class TestBase(TestCase):
             ]
         })
 
+    @pytest.mark.forked
     def test_normal(self):
         self.run_virtwho(['-i', '2', '-d'] + self.arguments, background=True)
         self.addCleanup(self.stop_virtwho)
@@ -333,6 +337,7 @@ class TestBase(TestCase):
         assoc = self.wait_for_assoc(5)
         self.check_assoc_updated(assoc)
 
+    @pytest.mark.forked
     def test_exit_on_SIGTERM(self):
         """
         This test shows that virt-who exits cleanly in response to the
@@ -345,6 +350,7 @@ class TestBase(TestCase):
         self.process.join(timeout=3)
         self.assertEqual(self.process.is_alive(), False)
 
+    @pytest.mark.forked
     def test_reload_on_SIGHUP(self):
         """
         This tests that the rhsm.conf is read once again when the process


### PR DESCRIPTION
We were running into occasional failures complaining of a port
 that is already in use.