### PR TITLE
2054504: Use usedforsecurity=False for md5() calls to make suds work on FIPS enabled systems

### DIFF
--- a/virtwho/virt/esx/suds/reader.py
+++ b/virtwho/virt/esx/suds/reader.py
@@ -58,7 +58,12 @@ class Reader(object):
         @rtype: str
 
         """
-        h = md5(name.encode()).hexdigest()
+        try:
+            # FIPS requires usedforsecurity=False and might not be
+            # available on all distros: https://bugs.python.org/issue9216
+            h = md5(name.encode(), usedforsecurity=False).hexdigest()
+        except (AttributeError, TypeError):
+            h = md5(name.encode()).hexdigest()
         return '%s-%s' % (h, x)
 
 

--- a/virtwho/virt/esx/suds/wsse.py
+++ b/virtwho/virt/esx/suds/wsse.py
@@ -156,7 +156,12 @@ class UsernameToken(Token):
             s.append(self.username)
             s.append(self.password)
             s.append(Token.sysdate())
-            m = md5()
+            try:
+                # FIPS requires usedforsecurity=False and might not be
+                # available on all distros: https://bugs.python.org/issue9216
+                m = md5(usedforsecurity=False)
+            except (AttributeError, TypeError):
+                m = md5()
             m.update(':'.join(s).encode('utf-8'))
             self.nonce = m.hexdigest()
         else:


### PR DESCRIPTION
Backport https://github.com/suds-community/suds/pull/72 to the virt-who copy of suds.