### PR TITLE
2124814: [1.30.5] Nutanix: Gather information about VMs correctly 

### DIFF
--- a/tests/test_ahv.py
+++ b/tests/test_ahv.py
@@ -27,7 +27,8 @@ PE_SECTION_VALUES = {
     'hypervisor_id': 'uuid',
     'is_hypervisor': True,
     'internal_debug': False,
-    'update_interval': 60
+    'update_interval': 60,
+    'wait_time_in_sec': 900
 }
 
 HOST_UVM_MAP = \

--- a/virtwho/virt/ahv/ahv.py
+++ b/virtwho/virt/ahv/ahv.py
@@ -1,4 +1,5 @@
 import socket
+import time as time_func
 
 from . import ahv_constants
 from .ahv_interface import AhvInterface, Failure
@@ -9,6 +10,8 @@ from virtwho.virt import Hypervisor, Guest
 
 DefaultUpdateInterval = 1800
 MinimumUpdateInterval = 60
+DefaultWaitTime = 900
+MinWaitTime = 60
 
 class Ahv(virt.Virt):
   "AHV Rest client"
@@ -45,6 +48,7 @@ class Ahv(virt.Virt):
     self.username = self.config['username']
     self.password = self.config['password']
     self.update_interval = self.config['update_interval']
+    self.wait_time = self.config['wait_time_in_sec']
     self._interface = AhvInterface(logger, self.url, self.username,
                                    self.password, self.port,
                                    internal_debug=self.config['internal_debug'])
@@ -77,6 +81,9 @@ class Ahv(virt.Virt):
                                                self.is_pc)
           if len(response) == 0:
             # No events, continue to wait
+            self.logger.debug('wait for %s seconds before looking for '
+                              'new events\n' % self.wait_time)
+            time_func.sleep(self.wait_time)
             continue
           self.logger.debug('AHV event found: %s\n' % response)
           return response
@@ -97,13 +104,13 @@ class Ahv(virt.Virt):
       None.
     """
     mapping = {'hypervisors': []}
-    
+
     host_uvm_map = self._interface.build_host_to_uvm_map(self.version)
 
     for host_uuid in host_uvm_map:
       host = host_uvm_map[host_uuid]
-    
-      try: 
+
+      try:
         if self.config['hypervisor_id'] == 'uuid':
           hypervisor_id = host_uuid
         elif self.config['hypervisor_id'] == 'hostname':
@@ -215,6 +222,10 @@ class AhvConfigSection(VirtConfigSection):
     self.add_key('update_interval',
                  validation_method=self._validate_update_interval,
                  default=DefaultUpdateInterval)
+    self.add_key(
+            'wait_time_in_sec',
+            validation_method=self._validate_wait_time,
+            default=DefaultWaitTime)
 
   def _validate_server(self, key):
     """
@@ -255,4 +266,32 @@ class AhvConfigSection(VirtConfigSection):
     except (TypeError, ValueError) as e:
       result = (
       'warning', '%s was not set to a valid integer: %s' % (key, str(e)))
+    return result
+
+  def _validate_wait_time(self, key):
+    """
+    Validate the wait time  flag.
+    Args:
+      key (Int): wait time value.
+    Returns:
+      A warning is returned in case update time is not valid.
+    """
+    result = None
+    try:
+      self._values[key] = int(self._values[key])
+
+      if self._values[key] < MinWaitTime:
+        message = (
+            "Wait time value can't be lower than {min} seconds. "
+            "Default value of {default} "
+            "seconds will be used.".format(min=MinWaitTime,
+                                          default=DefaultWaitTime)
+        )
+        result = ("warning", message)
+        self._values['interval'] = DefaultWaitTime
+    except KeyError:
+      result = ('warning', '%s is missing' % key)
+    except (TypeError, ValueError) as e:
+      result = ('warning', '%s was not set to a valid '
+                'integer: %s' % (key, str(e)))
     return result

--- a/virtwho/virt/ahv/ahv_constants.py
+++ b/virtwho/virt/ahv/ahv_constants.py
@@ -4,6 +4,7 @@ TASK_COMPLETE_MSG = ['SUCCEEDED', 'Succeeded']
 DEFAULT_PORT = 9440
 VERSION_2 = 'v2.0'
 VERSION_3 = 'v3'
+NUM_OF_REQUESTED_VMS = 20
 
 CMN_RST_CMD = {'get_vm': {'url': '/vms/%s', 'method': 'get'},
                'get_host': {'url': '/hosts/%s', 'method': 'get'},

--- a/virtwho/virt/ahv/ahv_interface.py
+++ b/virtwho/virt/ahv/ahv_interface.py
@@ -291,7 +291,10 @@ class AhvInterface(object):
     kwargs['verify'] = kwargs.get('verify', False)
     if 'timeout' not in kwargs:
       kwargs['timeout'] = self._timeout
-    if 'data' not in kwargs:
+    if 'json' in kwargs:
+      kwargs['data'] = json.dumps(kwargs['json'])
+      del kwargs['json']
+    else:
       body = {}
       kwargs['data'] = json.dumps(body)
     content_dict = {'content-type': 'application/json'}
@@ -359,7 +362,8 @@ class AhvInterface(object):
     # For task return. Use fv2.0 for now. update the url to use v2.0.
     url = self._url[:(self._url).rfind('v')] + 'v2.0' + uri
 
-    res = self._send(method=cmd_method, url=url)
+    body = {"entity_list": [{"entity_type": "kVm"}]}
+    res = self._send(method=cmd_method, url=url, json=body)
     data = res.json()
 
     if is_pc:


### PR DESCRIPTION
* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2124814
* Card ID: ENT-5361
* Backport to 1.30.5 branch
  * Original PR for main branch: https://github.com/candlepin/virt-who/pull/377
  * Original PR for 1.30 branch: https://github.com/candlepin/virt-who/pull/379
* Original PR and commits created by Robin Mazzeo
  * PR: https://github.com/candlepin/virt-who/pull/376
* I also had to cherry-pick this commit: 173aaeea85b5c2a270af898d5c66ba34a57ebcad otherwise request was sent without body.
* When version 3 of Nutanix API was used, then it was
  possible to gather only first 20 VMs