### PR TITLE
Update virt-who-config.5 for typo fix

### DIFF
--- a/virt-who-config.5
+++ b/virt-who-config.5
@@ -31,7 +31,7 @@ Enable debugging output
 Send the list of guest IDs and exit immediately
 .TP
 \fBlog_per_config\fR
-Write a seperate log file per configuration in the config directory
+Write a separate log file per configuration in the config directory
 .TP
 \fBlog_dir\fR
 The absolute path of the directory to write logs to.
@@ -135,7 +135,7 @@ Only hosts which uuid (or hostname or hwuuid, based on \fBhypervisor_id\fR) is s
 Hosts which uuid (or hostname or hwuuid, based on \fBhypervisor_id\fR) is specified in comma-separated list in this option will \fBNOT\fR be reported.  Wildcards and regular expressions are supported.  Put the value into the double-quotes if it contains special characters (like comma). \fBexclude_host_uuids\fR is deprecated alias for this option.
 .TP
 \fBfilter_type\fR
-When this propery is not set, then virt-who tries to detect wildcards or regular expression in value of filter_hosts or exclude_hosts. This option allows to specify usage of regular expression (value 'regex') or wildcards (value 'wildcards').
+When this property is not set, then virt-who tries to detect wildcards or regular expression in value of filter_hosts or exclude_hosts. This option allows to specify usage of regular expression (value 'regex') or wildcards (value 'wildcards').
 .TP
 \fBhypervisor_id\fR
 Property that should be used as identification of the hypervisor. Can be one of following: \fBuuid\fR, \fBhostname\fR, \fBhwuuid\fR. Note that some virtualization backends don't have all of them implemented. Default is \fBuuid\fR. \fBhwuuid\fR is applicable to esx and rhevm only. This property is meant to be set up before initial run of virt-who. Changing it later will result in duplicated entries in the subscription manager.


### PR DESCRIPTION
I found some typo when I was reading the manual and would like to fix them. 
seperate -> separate
propery -> property

Thanks!