### PR TITLE
Added configuration for rhel-9.0 into releasers.conf

### DIFF
--- a/rel-eng/releasers.conf
+++ b/rel-eng/releasers.conf
@@ -6,3 +6,11 @@ branches = main f35 f34
 releaser = tito.release.CentosGitReleaser
 branches = c9s
 required_bz_flags = release+
+
+[rhel-9.0]
+releaser = tito.release.DistGitReleaser
+branches = rhel-9.0.0
+required_bz_flags = release+
+# Change this if you wish to use a placeholder "rebase" bug if none
+# are found in the changelog.
+placeholder_bz =


### PR DESCRIPTION
* Extended releasers.conf file to be able to trigger new build easily with 'tito release rhel-9.0' for this branch