### PR TITLE
Added configuration for rhel-9.x into releasers.conf

### DIFF
--- a/rel-eng/releasers.conf
+++ b/rel-eng/releasers.conf
@@ -1,8 +1,24 @@
 [fedora]
 releaser = tito.release.FedoraGitReleaser
-branches = main f35 f34
+branches = main f36 f35
 
 [centos-9-stream]
 releaser = tito.release.CentosGitReleaser
 branches = c9s
 required_bz_flags = release+
+
+[rhel-9.0]
+releaser = tito.release.DistGitReleaser
+branches = rhel-9.0.0
+required_bz_flags = release+
+# Change this if you wish to use a placeholder "rebase" bug if none
+# are found in the changelog.
+placeholder_bz =
+
+[rhel-9.1]
+releaser = tito.release.DistGitReleaser
+branches = rhel-9.1.0
+required_bz_flags = release+
+# Change this if you wish to use a placeholder "rebase" bug if none
+# are found in the changelog.
+placeholder_bz =


### PR DESCRIPTION
* Extended releasers.conf file to be able to trigger new build easily with 'tito release rhel-9.x' for 9.x branches
* Updated information about Fedora branches