### PR TITLE
Added configuration for rhel-8.7 into releasers.conf

### DIFF
--- a/rel-eng/releasers.conf
+++ b/rel-eng/releasers.conf
@@ -18,3 +18,11 @@ required_bz_flags = release+
 # are found in the changelog.
 placeholder_bz = 
 
+[rhel-8.7]
+releaser = tito.release.DistGitReleaser
+branches = rhel-8.7.0
+required_bz_flags = release+
+# Change this if you wish to use a placeholder "rebase" bug if none
+# are found in the changelog.
+placeholder_bz =
+


### PR DESCRIPTION
* Extended releasers.conf file to be able to trigger new build easily with 'tito release rhel-8.7' for 8.7 branch