### PR TITLE
Nutanix: fix issue with prism_central option

### DIFF
--- a/tests/test_ahv.py
+++ b/tests/test_ahv.py
@@ -40,6 +40,7 @@ PE_SECTION_VALUES = {
     'username': 'root',
     'password': 'root_password',
     'owner': 'nutanix',
+    'prism_central': False,
     'hypervisor_id': 'uuid',
     'is_hypervisor': True,
     'ahv_internal_debug': False,

--- a/tests/test_config_section.py
+++ b/tests/test_config_section.py
@@ -200,7 +200,7 @@ class TestConfigSection(TestBase):
         expected_result = [
             (
                 'warning',
-                'my_bool must be a valid boolean, using default. See man virt-who-config for more info'
+                'my_bool must be a valid boolean, using default: True. See man virt-who-config for more info'
             ),
         ]
         self.assertEqual(result, expected_result)

--- a/virtwho/config.py
+++ b/virtwho/config.py
@@ -415,12 +415,12 @@ def parse_file(filename):
 def str_to_bool(value):
     if isinstance(value, bool):
         return value
-    if isinstance(value, str):
+    elif isinstance(value, str):
         if value.strip().lower() in ['yes', 'true', 'on', '1']:
             return True
         elif value.strip().lower() in ['no', 'false', 'off', '0']:
             return False
-    raise ValueError("Unable to convert value to boolean")
+    raise ValueError(f"Unable to convert value: \"{value}\" to boolean")
 
 
 def non_empty_string(value):
@@ -777,8 +777,8 @@ class ConfigSection(collections.abc.MutableMapping):
                 self._values[key] = str_to_bool(self.defaults[key])
                 result = (
                     'warning',
-                    '%s must be a valid boolean, using default. '
-                    'See man virt-who-config for more info' % key
+                    '%s must be a valid boolean, using default: %s. '
+                    'See man virt-who-config for more info' % (key, self._values[key])
                 )
             else:
                 result = (

--- a/virtwho/virt/ahv/ahv.py
+++ b/virtwho/virt/ahv/ahv.py
@@ -322,7 +322,7 @@ class AhvConfigSection(VirtConfigSection):
         self.add_key(
             'prism_central',
             validation_method=self._validate_str_to_bool,
-            default=None
+            default=False
         )
         self.add_key(
             'ahv_internal_debug',


### PR DESCRIPTION
* When wrong value for prism_central was set, then virt-who
  was terminated with traceback
* Default value is set to `False`
* When wrong value is provided for boolean option, then print
  this value in message of Error and print default value
  in log message