### PR TITLE
2126166: [1.30] Fixed issue with wrong state

### DIFF
--- a/virtwho/virt/ahv/ahv.py
+++ b/virtwho/virt/ahv/ahv.py
@@ -126,10 +126,9 @@ class Ahv(virt.Virt):
       if 'guest_list' in host and len(host['guest_list']) > 0:
         for guest_vm in host['guest_list']:
           try:
-            state = guest_vm['power_state']
-            if guest_vm['power_state'] == 'on':
+            if guest_vm['power_state'].upper() == 'ON':
               state = virt.Guest.STATE_RUNNING
-            elif guest_vm['power_state'] == 'off':
+            elif guest_vm['power_state'].upper() == 'OFF':
               state = virt.Guest.STATE_SHUTOFF
             else:
               state = virt.Guest.STATE_UNKNOWN


### PR DESCRIPTION
* BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2126166
* Card ID: ENT-5522
* When v3 API of Nutanix is used, then virt-who reported wrong state of VM
* It wasn't possible to do simple backport of this issue from main branch, because this was fixed during big refactoring in different way, and refactored code does not share code for two versions of API.