### PR TITLE
Drop outdated/unused requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,3 @@
-suds-py3;python_version>="3.0"
-suds;python_version<"3.0"
-git+https://github.com/candlepin/subscription-manager#egg=subscription_manager
-git+https://github.com/candlepin/python-iniparse#egg=iniparse;python_version>="3.0"
-iniparse;python_version<"3.0"
 requests>=2.0
-m2crypto;python_version<"3.0"
 cryptography
 PyYAML


### PR DESCRIPTION
- drop suds: now locally vendored
- drop subscription-manager: installing it from sources using pip is not something tested upstream anymore, so assume it is installed as system library
- drop iniparse & m2crypto: not used by virt-who (anymore?), likely needed by subscription-manager