### PR TITLE
Migrate to SPDX license

### DIFF
--- a/virt-who.spec
+++ b/virt-who.spec
@@ -5,7 +5,7 @@ Release:        1%{?dist}
 Summary:        Agent for reporting virtual guest IDs to subscription-manager
 
 # GPL for virt-who proper and LGPL for incorporated suds
-License:        GPLv2+ and LGPLv3+
+License:        GPL-2.0-or-later AND LGPL-3.0-or-later
 URL:            https://github.com/candlepin/virt-who
 Source0:        %{name}-%{version}.tar.gz
 


### PR DESCRIPTION
* Changed string definition of license in .spec file. Licenses remain the same. It is still GPL for virt-who and LGPL for suds.