### PR TITLE
Change /var/run -> /run

### DIFF
--- a/virt-who.service
+++ b/virt-who.service
@@ -4,7 +4,7 @@ After=libvirtd.service network.target
 
 [Service]
 Type=notify
-PIDFile=/var/run/virt-who.pid
+PIDFile=/run/virt-who.pid
 ExecStart=/usr/bin/virt-who
 TimeoutStopSec=5
 

--- a/virtwho/lock.py
+++ b/virtwho/lock.py
@@ -25,8 +25,8 @@ import os
 import time
 import fcntl
 
-PIDFILE = "/var/run/virt-who.pid"
-STATUS_LOCK = "/var/run/virt-who-status.pid"
+PIDFILE = "/run/virt-who.pid"
+STATUS_LOCK = "/run/virt-who-status.pid"
 STATUS_DATA = "/var/lib/virt-who/run_data.json"
 STATUS_DATA_DIR = "/var/lib/virt-who"
 DEFAULT_TIMEOUT = 1.0


### PR DESCRIPTION
systemd complains:
```
systemd[1]: /usr/lib/systemd/system/virt-who.service:7: PIDFile= references a path below legacy directory /var/run/, updating /var/run/virt-who.pid → /run/virt-who.pid; please update the unit file accordingly.
```