### PR TITLE
fix: Replace all warn() with warning()

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -979,14 +979,23 @@ owner=root
 
         self.assertEqual(config["server"], 'http://1.2.3.4\nvalue')
 
-    @patch('logging.Logger.warn')
-    def testCommentedOutLineContinuationInConfig(self, logger_warn):
+    @patch('logging.Logger.warning')
+    def testCommentedOutLineContinuationInConfig(self, logger_warning):
         """Test that when a config line that starts with space or tab which is followed by a '#',
         if we are running python2: it is treated as a continuation of the previous line,
         but a warning is logged for the user.
         If we are running python3: it is ignored as a comment, and no warning is logged.
-        :return:
         """
+        # Alter the main conf file constant temporarily:
+        virtwho.config.VW_GENERAL_CONF_PATH = os.path.join(self.general_config_file_dir, "virt-who.conf")
+        # We need to have [global] section with at least some value. Otherwise,
+        # init_config() returns warning, and we test that no warning is returned.
+        with open(virtwho.config.VW_GENERAL_CONF_PATH, "w") as f:
+            f.write("""
+[global]
+debug=True
+""")
+
         with open(os.path.join(self.config_dir, "test1.conf"), "w") as f:
             f.write("""
 [test1]
@@ -1003,8 +1012,8 @@ owner=root
         config = manager.configs[0][1]
         self.assertEqual(config.name, "test1")
         self.assertEqual(config["server"], "http://1.2.3.4")
-        self.assertFalse(logger_warn.called)
-        self.assertEqual(logger_warn.call_count, 0)
+        self.assertFalse(logger_warning.called)
+        self.assertEqual(logger_warning.call_count, 0)
 
 
 class TestParseList(TestBase):

--- a/virtwho/config.py
+++ b/virtwho/config.py
@@ -402,7 +402,7 @@ def parse_file(filename):
     except InvalidOption as e:
         # When a configuration section has an Invalid Option, continue
         # See https://bugzilla.redhat.com/show_bug.cgi?id=1457101 for more info
-        logger.warn("Invalid configuration detected: %s", str(e))
+        logger.warning("Invalid configuration detected: %s", str(e))
     except DuplicateOptionError as e:
         logger.warning(str(e))
     except Exception as e:
@@ -1342,15 +1342,15 @@ class EffectiveConfig(collections.abc.MutableMapping):
             conf_files = set(s for s in all_dir_content if s.endswith('.conf'))
             non_conf_files = all_dir_content - conf_files
         except OSError:
-            logger.warn("Configuration directory '%s' doesn't exist or is not accessible",
-                        config_dir)
+            logger.warning("Configuration directory '%s' doesn't exist or is not accessible",
+                           config_dir)
             return {}
 
         if not all_dir_content:
-            logger.warn("Configuration directory '%s' appears empty", config_dir)
+            logger.warning("Configuration directory '%s' appears empty", config_dir)
         elif not conf_files:
-            logger.warn("Configuration directory '%s' does not have any '*.conf' files but "
-                        "is not empty", config_dir)
+            logger.warning("Configuration directory '%s' does not have any '*.conf' files but "
+                           "is not empty", config_dir)
         elif non_conf_files:
             logger.debug("There are files in '%s' not ending in '*.conf' is this "
                          "intentional?", config_dir)
@@ -1372,8 +1372,8 @@ class EffectiveConfig(collections.abc.MutableMapping):
             all_dir_content = set(os.listdir(config_dir))
             conf_files = set(s for s in all_dir_content if s.endswith('.conf'))
         except OSError:
-            logger.warn("Configuration directory '%s' doesn't exist or is not accessible",
-                        config_dir)
+            logger.warning("Configuration directory '%s' doesn't exist or is not accessible",
+                           config_dir)
             return False
 
         if not conf_files:

--- a/virtwho/manager/satellite/satellite.py
+++ b/virtwho/manager/satellite/satellite.py
@@ -238,7 +238,7 @@ class Satellite(Manager):
                     self.server_xmlrpc.registration.virt_notify(hypervisor_systemid["system_id"], plan)
                 except xmlrpc.client.Fault as e:
                     if e.faultCode == -9:
-                        self.logger.warn("System was deleted from Satellite 5, reregistering")
+                        self.logger.warning("System was deleted from Satellite 5, re-registering")
                         hypervisor_systemid = self._load_hypervisor(hypervisor.hypervisorId,
                                                                     hypervisor_type=report.config['type'], force=True)
                         self.server_xmlrpc.registration.virt_notify(hypervisor_systemid["system_id"], plan)

--- a/virtwho/virt/libvirtd/libvirtd.py
+++ b/virtwho/virt/libvirtd/libvirtd.py
@@ -145,7 +145,7 @@ class LibvirtdConfigSection(VirtConfigSection):
                 server = self._values['server']
                 if 'ssh://' in server or '://' not in server:
                     result = [(
-                        'warn',
+                        'warning',
                         "Password authentication doesn't work with ssh transport on libvirt backend, "
                         "copy your public ssh key to the remote machine"
                     )]


### PR DESCRIPTION
* The warn() has been deprecated for very long time and it just become not available
   in the newest version of Python 3.13
   https://docs.python.org/3.13/whatsnew/3.13.html#logging
* Fixed one unit test