### PR TITLE
fix(docks): fix duplicate numbering in virt-who man page

### DIFF
--- a/virt-who.8
+++ b/virt-who.8
@@ -49,7 +49,7 @@ This is the default mode. virt-who will listen to change events (if available) o
 
 This mode is similar to oneshot mode but the host to guest association is not send to server, but printed to standard output instead.
 .TP
-3. status mode
+4. status mode
 # virt-who -s
 
 This mode is for configuration diagnosis. The host to guest association is not compiled and is not sent to the server. When executed, it will confirm the ability to log into and retrieve data from the source for each configuration. It will also confirm the credentials and organization for each destination in the configurations.


### PR DESCRIPTION
Correct "status mode" numbering from 3. to 4. in the USAGE section.