### PR TITLE
fix: Handle hypervisor_id option properly

### DIFF
--- a/tests/test_ahv.py
+++ b/tests/test_ahv.py
@@ -666,6 +666,136 @@ HOST_UVM_MAP_3 = {
     },
 }
 
+HOST_UVM_MAP_4 = {
+    "08469de5-be42-43e6-8c32-20167d3b58f7": {
+        "oplog_disk_pct": 3.4,
+        "memory_capacity_in_bytes": 135009402880,
+        "has_csr": False,
+        "default_vm_storage_container_uuid": None,
+        "hypervisor_username": "root",
+        "key_management_device_to_certificate_status": {},
+        "service_vmnat_ip": None,
+        "hypervisor_key": "10.53.97.188",
+        "acropolis_connection_state": "kConnected",
+        "management_server_name": "10.53.97.188",
+        "failover_cluster_fqdn": None,
+        "serial": "OM155S016008",
+        "bmc_version": "01.92",
+        "hba_firmwares_list": [
+            {
+                "hba_model": "LSI Logic SAS3008",
+                "hba_version": "MPTFW-06.00.00.00-IT",
+            }
+        ],
+        "hypervisor_state": "kAcropolisNormal",
+        "num_cpu_threads": 32,
+        "monitored": True,
+        "uuid": "08469de5-be42-43e6-8c32-20167d3b58f7",
+        "reboot_pending": False,
+        "cpu_capacity_in_hz": 38384000000,
+        "num_cpu_sockets": 2,
+        "host_maintenance_mode_reason": None,
+        "hypervisor_address": "10.53.97.188",
+        "host_gpus": None,
+        "failover_cluster_node_state": None,
+        "state": "NORMAL",
+        "num_cpu_cores": 16,
+        "guest_list": [
+            {
+                "vm_features": {"AGENT_VM": False, "VGA_CONSOLE": True},
+                "num_cores_per_vcp": 1,
+                "gpus_assigned": False,
+                "num_vcpus": 2,
+                "memory_mb": 4096,
+                "power_state": "on",
+                "ha_priority": 0,
+                "allow_live_migrate": True,
+                "timezone": "America/Los_Angeles",
+                "vm_logical_timestamp": 48,
+                "host_uuid": "08469de5-be42-43e6-8c32-20167d3b58f7",
+                "uuid": "01dcfc0b-3092-4f1b-94fb-81b44ed352be",
+            },
+            {
+                "vm_features": {"AGENT_VM": False, "VGA_CONSOLE": True},
+                "num_cores_per_vcp": 1,
+                "gpus_assigned": False,
+                "num_vcpus": 2,
+                "memory_mb": 4096,
+                "power_state": "on",
+                "ha_priority": 0,
+                "allow_live_migrate": True,
+                "timezone": "America/Los_Angeles",
+                "vm_logical_timestamp": 3,
+                "host_uuid": "08469de5-be42-43e6-8c32-20167d3b58f7",
+                "uuid": "422f9171-db1f-48b0-a3de-b0bb92a8f559",
+            },
+            {
+                "vm_features": {"AGENT_VM": False, "VGA_CONSOLE": True},
+                "num_cores_per_vcp": 1,
+                "gpus_assigned": False,
+                "num_vcpus": 2,
+                "memory_mb": 4096,
+                "power_state": "on",
+                "ha_priority": 0,
+                "allow_live_migrate": True,
+                "timezone": "America/Los_Angeles",
+                "vm_logical_timestamp": 3,
+                "host_uuid": "08469de5-be42-43e6-8c32-20167d3b58f7",
+                "uuid": "98839f35-bd62-4255-a7cd-7668bc143554",
+            },
+        ],
+        "cpu_model": "Intel(R) Xeon(R) CPU E5-2630 v3 @ 2.40GHz",
+        "ipmi_username": "ADMIN",
+        "service_vmid": "0005809e-62e4-75c7-611b-0cc47ac3b354::7",
+        "bmc_model": "X10_ATEN",
+        "host_nic_ids": [],
+        "cluster_uuid": None,
+        "ipmi_password": None,
+        "cpu_frequency_in_hz": 2399000000,
+        "stats": {
+            "num_read_io": "8",
+            "controller_read_io_bandwidth_kBps": "0",
+            "content_cache_hit_ppm": "1000000",
+        },
+        "num_vms": 4,
+        "default_vm_storage_container_id": None,
+        "metadata_store_status": "kNormalMode",
+        "hypervisor_password": None,
+        "service_vmnat_port": None,
+        "hypervisor_full_name": "Nutanix 20180802.100874",
+        "is_degraded": False,
+        "host_type": "HYPER_CONVERGED",
+        "default_vhd_storage_container_uuid": None,
+        "block_serial": "15SM60250038",
+        "disk_hardware_configs": {
+            "1": {
+                "mount_path": "/home/nutanix/data/stargate-storage/disks/BTHC506101XL480MGN",
+            },
+            "3": {
+                "mount_path": "/home/nutanix/data/stargate-storage/disks/9XG8E6QE",
+            },
+            "2": {
+                "mount_path": "/home/nutanix/data/stargate-storage/disks/BTHC50610246480MGN",
+            },
+            "5": {
+                "mount_path": "/home/nutanix/data/stargate-storage/disks/9XG8E835",
+            },
+            "4": {
+                "mount_path": "/home/nutanix/data/stargate-storage/disks/9XG8E8B1",
+            },
+            "6": {
+                "mount_path": "/home/nutanix/data/stargate-storage/disks/9XG8E7B3",
+            },
+        },
+        "ipmi_address": "10.49.27.28",
+        "bios_model": "0824",
+        "default_vm_location": None,
+        "hypervisor_type": "kKvm",
+        "service_vmexternal_ip": "10.53.97.192",
+        "controller_vm_backplane_ip": "10.53.97.192",
+    },
+}
+
 
 class TestAhvConfigSection(TestBase):
     """
@@ -1028,6 +1158,46 @@ class TestAhv(TestBase):
 
             expected_result.append(Hypervisor(
                 name=host_name,
+                hypervisorId=hypervisor_id,
+                guestIds=guests,
+                facts=facts
+            ))
+
+        result = self.ahv.getHostGuestMapping()['hypervisors']
+
+        self.assertEqual(
+            len(result),
+            len(expected_result),
+            'lists length do not match'
+        )
+
+        for index in range(0, len(result)):
+            self.assertEqual(expected_result[index].toDict(), result[index].toDict())
+
+    @patch('virtwho.virt.ahv.ahv_interface.AhvInterface2.get_ahv_cluster_uuid_name_list')
+    @patch('virtwho.virt.ahv.ahv_interface.AhvInterface2.build_host_to_uvm_map')
+    def test_getHostGuestMapping_no_name(self, host_to_uvm_map, cluster_names):
+        host_to_uvm_map.return_value = HOST_UVM_MAP_4
+        cluster_names.return_value = CLUSTER_NAMES_BLANK
+
+        expected_result = []
+
+        for host_uuid in HOST_UVM_MAP_4:
+            host = HOST_UVM_MAP_4[host_uuid]
+            hypervisor_id = host_uuid
+            guests = []
+            for guest_vm in host['guest_list']:
+                state = virt.Guest.STATE_RUNNING
+                guests.append(Guest(guest_vm["uuid"], self.ahv.CONFIG_TYPE, state))
+
+            facts = {
+               Hypervisor.CPU_SOCKET_FACT: '2',
+               Hypervisor.HYPERVISOR_TYPE_FACT: u'kKvm',
+               Hypervisor.HYPERVISOR_VERSION_FACT: 'Nutanix 20180802.100874',
+               Hypervisor.SYSTEM_UUID_FACT: str(host_uuid)
+            }
+
+            expected_result.append(Hypervisor(
                 hypervisorId=hypervisor_id,
                 guestIds=guests,
                 facts=facts

--- a/virtwho/virt/ahv/ahv.py
+++ b/virtwho/virt/ahv/ahv.py
@@ -104,7 +104,6 @@ class Ahv(virt.Virt):
             Dictionary with host-guest mapping
         """
         mapping = {'hypervisors': []}
-        hypervisor_id = None
 
         host_uvm_map = self._interface.build_host_to_uvm_map()
 
@@ -113,15 +112,18 @@ class Ahv(virt.Virt):
         for host_uuid in host_uvm_map:
             host = host_uvm_map[host_uuid]
 
-            try:
-                if self.config['hypervisor_id'] == 'uuid':
-                    hypervisor_id = host_uuid
-                elif self.config['hypervisor_id'] == 'hostname':
+            # Set hypervisor_id to default uuid. The self.config['hypervisor_id']
+            # can have only two possible values: 'uuid' or 'hostname' at this point.
+            hypervisor_id = host_uuid
+            if self.config['hypervisor_id'] == 'uuid':
+                self.logger.debug("Using hypervisor_id: uuid: %s", hypervisor_id)
+            elif self.config['hypervisor_id'] == 'hostname':
+                try:
                     hypervisor_id = host['name']
-
-            except KeyError:
-                self.logger.debug("Host '%s' doesn't have hypervisor_id property", host_uuid)
-                continue
+                    self.logger.debug("Using hypervisor_id: hostname: %s", hypervisor_id)
+                except KeyError:
+                    self.logger.warning("Host '%s' doesn't have 'name' property", host_uuid)
+                    self.logger.warning("Falling back to default hypervisor_id: uuid")
 
             guests = []
             if 'guest_list' in host and len(host['guest_list']) > 0:
@@ -147,7 +149,10 @@ class Ahv(virt.Virt):
 
             cluster_name = self._interface.get_host_cluster_name(host, cluster_uuid_name_list)
             host_version = self._interface.get_host_version(host)
-            host_name = host["status"]['name']
+            try:
+                host_name = host["status"]['name']
+            except KeyError:
+                host_name = None
 
             facts = {
                 Hypervisor.CPU_SOCKET_FACT: str(host["status"]["resources"]['num_cpu_sockets']),
@@ -176,7 +181,6 @@ class Ahv(virt.Virt):
         """
 
         mapping = {'hypervisors': []}
-        hypervisor_id = None
 
         host_uvm_map = self._interface.build_host_to_uvm_map()
 
@@ -185,15 +189,18 @@ class Ahv(virt.Virt):
         for host_uuid in host_uvm_map:
             host = host_uvm_map[host_uuid]
 
-            try:
-                if self.config['hypervisor_id'] == 'uuid':
-                    hypervisor_id = host_uuid
-                elif self.config['hypervisor_id'] == 'hostname':
+            # Set hypervisor_id to default uuid. The self.config['hypervisor_id']
+            # can have only two possible values: 'uuid' or 'hostname' at this point.
+            hypervisor_id = host_uuid
+            if self.config['hypervisor_id'] == 'uuid':
+                self.logger.debug("Using hypervisor_id: uuid: %s", hypervisor_id)
+            elif self.config['hypervisor_id'] == 'hostname':
+                try:
                     hypervisor_id = host['name']
-
-            except KeyError:
-                self.logger.debug("Host '%s' doesn't have hypervisor_id property", host_uuid)
-                continue
+                    self.logger.debug("Using hypervisor_id: hostname: %s", hypervisor_id)
+                except KeyError:
+                    self.logger.warning("Host '%s' doesn't have 'name' property", host_uuid)
+                    self.logger.warning("Falling back to default hypervisor_id: uuid")
 
             guests = []
             if 'guest_list' in host and len(host['guest_list']) > 0:
@@ -217,7 +224,10 @@ class Ahv(virt.Virt):
 
             cluster_name = self._interface.get_host_cluster_name(host, cluster_uuid_name_list)
             host_version = self._interface.get_host_version(host)
-            host_name = host['name']
+            try:
+                host_name = host['name']
+            except KeyError:
+                host_name = None
 
             facts = {
                 Hypervisor.CPU_SOCKET_FACT: str(host['num_cpu_sockets']),


### PR DESCRIPTION
* Card ID: CCT-2241
* When `hypervisor_id` is set to hostname and Nutanix does not provide `name` property in host object, then fallback to `uuid` for `hypervisor_id`