### PR TITLE
fix: handle str message decode in ESX Request/Reply unicode method

### DIFF
--- a/tests/test_suds_transport.py
+++ b/tests/test_suds_transport.py
@@ -1,0 +1,42 @@
+from __future__ import print_function
+
+import unittest
+
+from virtwho.virt.esx.suds.transport import Request, Reply
+
+
+class TestRequestUnicode(unittest.TestCase):
+    """Regression tests for Request/Reply.__unicode__ with str vs bytes messages.
+
+    Python 3.14+ pytest eagerly formats log arguments, which triggers
+    __str__ -> __unicode__ on Request objects during HttpTransport.send().
+    Previously, __unicode__ unconditionally called message.decode() which
+    fails when message is a str rather than bytes.
+    """
+
+    def test_request_str_message(self):
+        r = Request("http://example.com", message="hello")
+        result = str(r)
+        self.assertIn("hello", result)
+        self.assertIn("http://example.com", result)
+
+    def test_request_bytes_message(self):
+        r = Request("http://example.com", message=b"hello")
+        result = str(r)
+        self.assertIn("hello", result)
+
+    def test_request_none_message(self):
+        r = Request("http://example.com")
+        result = str(r)
+        self.assertNotIn("MESSAGE", result)
+
+    def test_reply_str_message(self):
+        r = Reply(200, {}, "response body")
+        result = str(r)
+        self.assertIn("response body", result)
+        self.assertIn("200", result)
+
+    def test_reply_bytes_message(self):
+        r = Reply(200, {}, b"response body")
+        result = str(r)
+        self.assertIn("response body", result)

--- a/virtwho/virt/esx/suds/transport/__init__.py
+++ b/virtwho/virt/esx/suds/transport/__init__.py
@@ -71,7 +71,10 @@ class Request(UnicodeMixin):
         result = ["URL: %s\nHEADERS: %s" % (self.url, self.headers)]
         if self.message is not None:
             result.append("MESSAGE:")
-            result.append(self.message.decode("raw_unicode_escape"))
+            if isinstance(self.message, bytes):
+                result.append(self.message.decode("raw_unicode_escape"))
+            else:
+                result.append(self.message)
         return "\n".join(result)
 
     def __set_URL(self, url):
@@ -120,11 +123,14 @@ class Reply(UnicodeMixin):
         self.message = message
 
     def __unicode__(self):
+        msg = self.message
+        if isinstance(msg, bytes):
+            msg = msg.decode("raw_unicode_escape")
         return """\
 CODE: %s
 HEADERS: %s
 MESSAGE:
-%s""" % (self.code, self.headers, self.message.decode("raw_unicode_escape"))
+%s""" % (self.code, self.headers, msg)
 
 
 class Transport(object):


### PR DESCRIPTION
Request.__unicode__() and Reply.__unicode__() unconditionally called .decode("raw_unicode_escape") on self.message, which fails with AttributeError on Python 3.14+ when message is a str rather than bytes. This broke 24 suds transport tests on Fedora latest (Python 3.14) where pytest's log capture eagerly formats the log arguments.

Guard .decode() with an isinstance(message, bytes) check so both str and bytes messages are handled correctly.

Assisted-by: Cursor