### PR TITLE
feat(hyperv): Update HyperV backend to support kerberos authentication

### DIFF
--- a/scripts/container-pre-test.sh
+++ b/scripts/container-pre-test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 dnf install -y libnl3-devel python3-libvirt python3-dateutil python3-setuptools python3-pip dnf-plugins-core \
-    python3-requests python3-cryptography python3-subscription-manager-rhsm subscription-manager
+    python3-requests python3-cryptography python3-requests-gssapi python3-subscription-manager-rhsm subscription-manager
 dnf builddep -y virt-who.spec
 
 pip install -r requirements.txt

--- a/tests/test_config_section_hyperv.py
+++ b/tests/test_config_section_hyperv.py
@@ -21,8 +21,25 @@ from __future__ import print_function
 Test validating of HypervConfigSection
 """
 
+import os
+import tempfile
+
+from functools import wraps
+
 from base import ConfigSectionValidationTests, TestBase
+from virtwho.config import ValidationState
 from virtwho.virt.hyperv.hyperv import HypervConfigSection
+
+
+def with_named_tempfile(func):
+    @wraps(func)
+    def inner(*args, **kwargs):
+        f = tempfile.NamedTemporaryFile(delete=False)
+        try:
+            return func(*args, f.name, **kwargs)
+        finally:
+            os.unlink(f.name)
+    return inner
 
 
 class TestHyperVConfigSection(ConfigSectionValidationTests, TestBase):
@@ -52,3 +69,229 @@ class TestHyperVConfigSection(ConfigSectionValidationTests, TestBase):
         'hypervisor_id': 'uuid',
         'sm_type': 'sam',
     }
+
+    def test_auth_method_default_is_basic(self):
+        """auth_method defaults to 'basic' when not specified."""
+        config = self.CONFIG_CLASS.from_dict(self.VALID_CONFIG, "test", None)
+        config.validate()
+        self.assertEqual(config.state, ValidationState.VALID)
+        self.assertEqual(config['auth_method'], 'basic')
+
+    def test_auth_method_basic_requires_username_and_password(self):
+        """auth_method=basic still requires username and password."""
+        values = dict(self.VALID_CONFIG, auth_method='basic')
+        del values['password']
+        config = self.CONFIG_CLASS.from_dict(values, "test", None)
+        messages = config.validate()
+        self.assertEqual(config.state, ValidationState.INVALID)
+        self.assertEqual(config['auth_method'], 'basic')
+        self.assertTrue(any('password' in msg[1].lower() and msg[0] == 'error' for msg in messages))
+
+    def test_auth_method_basic_explicit_valid(self):
+        """auth_method=basic with full credentials is valid."""
+        values = dict(self.VALID_CONFIG, auth_method='basic')
+        config = self.CONFIG_CLASS.from_dict(values, "test", None)
+        config.validate()
+        self.assertEqual(config.state, ValidationState.VALID)
+        self.assertEqual(config['auth_method'], 'basic')
+
+    def test_auth_method_kerberos_valid_without_password(self):
+        """auth_method=kerberos is valid without password."""
+        values = dict(self.VALID_CONFIG, auth_method='kerberos')
+        del values['password']
+        config = self.CONFIG_CLASS.from_dict(values, "test", None)
+        config.validate()
+        self.assertEqual(config.state, ValidationState.VALID)
+        self.assertEqual(config['auth_method'], 'kerberos')
+
+    def test_auth_method_kerberos_valid_without_username(self):
+        """auth_method=kerberos is valid without username."""
+        values = dict(self.VALID_CONFIG, auth_method='kerberos')
+        del values['username']
+        config = self.CONFIG_CLASS.from_dict(values, "test", None)
+        config.validate()
+        self.assertEqual(config.state, ValidationState.VALID)
+        self.assertEqual(config['auth_method'], 'kerberos')
+
+    def test_auth_method_kerberos_valid_without_username_and_password(self):
+        """auth_method=kerberos is valid without both username and password."""
+        values = dict(self.VALID_CONFIG, auth_method='kerberos')
+        del values['username']
+        del values['password']
+        config = self.CONFIG_CLASS.from_dict(values, "test", None)
+        config.validate()
+        self.assertEqual(config.state, ValidationState.VALID)
+        self.assertEqual(config['auth_method'], 'kerberos')
+
+    def test_auth_method_invalid_value(self):
+        """Invalid auth_method yields a clear validation error."""
+        values = dict(self.VALID_CONFIG, auth_method='ntlm')
+        config = self.CONFIG_CLASS.from_dict(values, "test", None)
+        messages = config.validate()
+        self.assertEqual(config.state, ValidationState.INVALID)
+        error_messages = [msg for msg in messages if msg[0] == 'error']
+        self.assertGreater(len(error_messages), 0)
+        self.assertTrue(any('auth_method' in msg[1] for msg in error_messages))
+
+    def test_auth_method_wired_through_config(self):
+        """auth_method appears in the config dict after validation."""
+        for auth_method in ('basic', 'kerberos'):
+            values = dict(self.VALID_CONFIG, auth_method=auth_method)
+            config = self.CONFIG_CLASS.from_dict(values, "test", None)
+            config.validate()
+            self.assertIn('auth_method', config)
+            self.assertEqual(config['auth_method'], auth_method)
+
+    def test_auth_method_kerberos_server_still_required(self):
+        """auth_method=kerberos still requires server."""
+        values = dict(self.VALID_CONFIG, auth_method='kerberos')
+        del values['server']
+        del values['username']
+        del values['password']
+        config = self.CONFIG_CLASS.from_dict(values, "test", None)
+        config.validate()
+        self.assertEqual(config.state, ValidationState.INVALID)
+        self.assertEqual(config['auth_method'], 'kerberos')
+
+    def test_kerberos_warns_when_username_provided(self):
+        """auth_method=kerberos warns that username is ignored."""
+        values = dict(self.VALID_CONFIG, auth_method='kerberos')
+        config = self.CONFIG_CLASS.from_dict(values, "test", None)
+        messages = config.validate()
+        self.assertEqual(config.state, ValidationState.VALID)
+        self.assertEqual(config['auth_method'], 'kerberos')
+        self.assertTrue(
+            any('username' in msg[1].lower() and 'ignored' in msg[1].lower()
+                for msg in messages if msg[0] == 'warning')
+        )
+
+    def test_kerberos_warns_when_password_provided(self):
+        """auth_method=kerberos warns that password is ignored."""
+        values = dict(self.VALID_CONFIG, auth_method='kerberos')
+        config = self.CONFIG_CLASS.from_dict(values, "test", None)
+        messages = config.validate()
+        self.assertEqual(config.state, ValidationState.VALID)
+        self.assertEqual(config['auth_method'], 'kerberos')
+        self.assertTrue(
+            any('password' in msg[1].lower() and 'ignored' in msg[1].lower()
+                for msg in messages if msg[0] == 'warning')
+        )
+
+    def test_kerberos_no_credential_warning_when_absent(self):
+        """auth_method=kerberos produces no ignored-credential warning when creds absent."""
+        values = dict(self.VALID_CONFIG, auth_method='kerberos')
+        del values['username']
+        del values['password']
+        config = self.CONFIG_CLASS.from_dict(values, "test", None)
+        messages = config.validate()
+        self.assertEqual(config.state, ValidationState.VALID)
+        self.assertEqual(config['auth_method'], 'kerberos')
+        self.assertFalse(
+            any('ignored' in msg[1].lower() for msg in messages if msg[0] == 'warning')
+        )
+
+    def test_kerberos_principal_accepted(self):
+        """kerberos_principal is accepted when auth_method=kerberos."""
+        values = dict(self.VALID_CONFIG, auth_method='kerberos',
+                      kerberos_principal='virtwho@EXAMPLE.COM')
+        del values['username']
+        del values['password']
+        config = self.CONFIG_CLASS.from_dict(values, "test", None)
+        config.validate()
+        self.assertEqual(config.state, ValidationState.VALID)
+        self.assertEqual(config['auth_method'], 'kerberos')
+        self.assertEqual(config['kerberos_principal'], 'virtwho@EXAMPLE.COM')
+
+    def test_kerberos_principal_ignored_with_basic(self):
+        """kerberos_principal with auth_method=basic produces a warning and is removed."""
+        values = dict(self.VALID_CONFIG, auth_method='basic',
+                      kerberos_principal='virtwho@EXAMPLE.COM')
+        config = self.CONFIG_CLASS.from_dict(values, "test", None)
+        messages = config.validate()
+        self.assertEqual(config.state, ValidationState.VALID)
+        self.assertEqual(config['auth_method'], 'basic')
+        self.assertTrue(
+            any('kerberos_principal' in msg[1] and 'ignoring' in msg[1].lower()
+                for msg in messages if msg[0] == 'warning')
+        )
+        self.assertNotIn('kerberos_principal', config)
+
+    def test_kerberos_principal_empty_string_is_error(self):
+        """Empty kerberos_principal is an error."""
+        values = dict(self.VALID_CONFIG, auth_method='kerberos',
+                      kerberos_principal='')
+        del values['username']
+        del values['password']
+        config = self.CONFIG_CLASS.from_dict(values, "test", None)
+        messages = config.validate()
+        self.assertEqual(config.state, ValidationState.INVALID)
+        self.assertEqual(config['auth_method'], 'kerberos')
+        self.assertTrue(any('kerberos_principal' in msg[1] and msg[0] == 'error' for msg in messages))
+
+    @with_named_tempfile
+    def test_kerberos_keytab_valid_file(self, keytab_path):
+        """kerberos_keytab with a readable file is accepted."""
+        values = dict(self.VALID_CONFIG, auth_method='kerberos',
+                      kerberos_keytab=keytab_path)
+        del values['username']
+        del values['password']
+        config = self.CONFIG_CLASS.from_dict(values, "test", None)
+        config.validate()
+        self.assertEqual(config.state, ValidationState.VALID)
+        self.assertEqual(config['auth_method'], 'kerberos')
+        self.assertEqual(config['kerberos_keytab'], keytab_path)
+
+    def test_kerberos_keytab_nonexistent_file_is_error(self):
+        """kerberos_keytab pointing to a missing file is an error."""
+        values = dict(self.VALID_CONFIG, auth_method='kerberos',
+                      kerberos_keytab='/no/such/file.keytab')
+        del values['username']
+        del values['password']
+        config = self.CONFIG_CLASS.from_dict(values, "test", None)
+        messages = config.validate()
+        self.assertEqual(config.state, ValidationState.INVALID)
+        self.assertEqual(config['auth_method'], 'kerberos')
+        self.assertTrue(any('kerberos_keytab' in msg[1] and msg[0] == 'error' for msg in messages))
+
+    @with_named_tempfile
+    def test_kerberos_keytab_ignored_with_basic(self, keytab_path):
+        """kerberos_keytab with auth_method=basic produces a warning and is removed."""
+        values = dict(self.VALID_CONFIG, auth_method='basic',
+                      kerberos_keytab=keytab_path)
+        config = self.CONFIG_CLASS.from_dict(values, "test", None)
+        messages = config.validate()
+        self.assertEqual(config.state, ValidationState.VALID)
+        self.assertEqual(config['auth_method'], 'basic')
+        self.assertTrue(
+            any('kerberos_keytab' in msg[1] and 'ignoring' in msg[1].lower()
+                for msg in messages if msg[0] == 'warning')
+        )
+        self.assertNotIn('kerberos_keytab', config)
+
+    def test_kerberos_keytab_optional(self):
+        """kerberos_keytab is optional even when auth_method=kerberos."""
+        values = dict(self.VALID_CONFIG, auth_method='kerberos')
+        del values['username']
+        del values['password']
+        config = self.CONFIG_CLASS.from_dict(values, "test", None)
+        config.validate()
+        self.assertEqual(config.state, ValidationState.VALID)
+        self.assertEqual(config['auth_method'], 'kerberos')
+
+    @with_named_tempfile
+    def test_full_kerberos_config(self, keytab_path):
+        """Full kerberos config with keytab and principal validates."""
+        values = {
+            "type": "hyperv",
+            "server": "hyperv.example.com",
+            "auth_method": "kerberos",
+            "kerberos_keytab": keytab_path,
+            "kerberos_principal": "virtwho@EXAMPLE.COM",
+            "owner": "1234567",
+        }
+        config = self.CONFIG_CLASS.from_dict(values, "test", None)
+        config.validate()
+        self.assertEqual(config.state, ValidationState.VALID)
+        self.assertEqual(config['auth_method'], 'kerberos')
+        self.assertEqual(config['kerberos_keytab'], keytab_path)
+        self.assertEqual(config['kerberos_principal'], 'virtwho@EXAMPLE.COM')

--- a/tests/test_hyperv.py
+++ b/tests/test_hyperv.py
@@ -31,7 +31,7 @@ from base import TestBase
 from proxy import Proxy
 
 from virtwho import DefaultInterval
-from virtwho.virt.hyperv.hyperv import HyperV, HypervConfigSection
+from virtwho.virt.hyperv.hyperv import HyperV, HypervConfigSection, HyperVException
 from virtwho.virt import VirtError, Guest, Hypervisor, StatusReport
 
 
@@ -334,3 +334,141 @@ class TestHyperV(TestBase):
         logger_debug.assert_called_with(
             'Invalid response (403) from Hyper-V (error: not well-formed (invalid token): line 8, column 18)'
         )
+
+
+class TestHyperVKerberosConnect(TestBase):
+    """Tests for the kerberos auth wiring in HyperV.connect()."""
+
+    def _make_hyperv(self, auth_method='kerberos', keytab=None, principal=None):
+        config_values = {
+            'type': 'hyperv',
+            'server': 'hyperv.example.com',
+            'auth_method': auth_method,
+            'owner': 'owner',
+        }
+        if keytab:
+            config_values['kerberos_keytab'] = keytab
+        if principal:
+            config_values['kerberos_principal'] = principal
+        config = HypervConfigSection('test', None)
+        config.update(**config_values)
+        config.validate()
+        return HyperV(self.logger, config, None, interval=DefaultInterval)
+
+    @patch('requests.Session')
+    def test_basic_auth_uses_hypervauth(self, session):
+        """auth_method=basic uses the HyperVAuth handler."""
+        from virtwho.virt.hyperv.hyperv import HyperVAuth
+        config_values = {
+            'type': 'hyperv',
+            'server': 'hyperv.example.com',
+            'auth_method': 'basic',
+            'username': 'user',
+            'password': 'pass',
+            'owner': 'owner',
+        }
+        config = HypervConfigSection('test', None)
+        config.update(**config_values)
+        config.validate()
+        hyperv = HyperV(self.logger, config, None, interval=DefaultInterval)
+
+        s = hyperv.connect()
+        self.assertIsInstance(s.auth, HyperVAuth)
+
+    @patch('virtwho.virt.hyperv.hyperv.gssapi.Credentials')
+    @patch('requests.Session')
+    def test_kerberos_auth_uses_httpspnegoauth(self, session, mock_credentials):
+        """auth_method=kerberos uses HTTPSPNEGOAuth."""
+        from requests_gssapi import HTTPSPNEGOAuth
+        hyperv = self._make_hyperv()
+        s = hyperv.connect()
+        self.assertIsInstance(s.auth, HTTPSPNEGOAuth)
+
+    @patch('virtwho.virt.hyperv.hyperv.gssapi.Credentials')
+    @patch('requests.Session')
+    def test_kerberos_sets_principal(self, session, mock_credentials):
+        """kerberos_principal is used to acquire gssapi.Credentials passed to HTTPSPNEGOAuth."""
+        sentinel_creds = object()
+        mock_credentials.return_value = sentinel_creds
+
+        hyperv = self._make_hyperv(principal='virtwho@EXAMPLE.COM')
+        s = hyperv.connect()
+
+        called_name = mock_credentials.call_args.kwargs['name']
+        self.assertEqual(str(called_name), 'virtwho@EXAMPLE.COM')
+        self.assertEqual(mock_credentials.call_args.kwargs['usage'], 'initiate')
+        self.assertIs(s.auth.creds, sentinel_creds)
+
+    @patch('virtwho.virt.hyperv.hyperv.gssapi.Credentials')
+    @patch('requests.Session')
+    def test_kerberos_principal_credential_failure_raises_clean_error(self, session, mock_credentials):
+        """A GSSError while acquiring credentials for the principal surfaces as HyperVException."""
+        import gssapi
+
+        class FakeGSSError(gssapi.exceptions.GSSError):
+            def __str__(self):
+                return 'no matching credentials in cache collection'
+
+        error = FakeGSSError.__new__(FakeGSSError)
+        BaseException.__init__(error, 'no matching credentials in cache collection')
+        mock_credentials.side_effect = error
+
+        hyperv = self._make_hyperv(principal='virtwho@EXAMPLE.COM')
+        self.assertRaises(HyperVException, hyperv.connect)
+
+    @patch('virtwho.virt.hyperv.hyperv.gssapi.Credentials')
+    @patch('requests.Session')
+    def test_kerberos_sets_keytab_store(self, session, mock_credentials):
+        """kerberos_keytab is passed to gssapi.Credentials via the 'store' argument."""
+        import tempfile
+        with tempfile.NamedTemporaryFile(delete=False) as f:
+            keytab_path = f.name
+        try:
+            hyperv = self._make_hyperv(keytab=keytab_path)
+            hyperv.connect()
+
+            called_store = mock_credentials.call_args.kwargs['store']
+            self.assertEqual(called_store, {"client_keytab": "FILE:%s" % keytab_path})
+        finally:
+            os.unlink(keytab_path)
+
+    @patch('virtwho.virt.hyperv.hyperv.gssapi.Credentials')
+    @patch('requests.Session')
+    def test_kerberos_no_principal_or_keytab_uses_defaults(self, session, mock_credentials):
+        """Without kerberos_principal/kerberos_keytab, gssapi.Credentials is still called,
+        with name and store left as None so the default credential cache is used."""
+        sentinel_creds = Mock(name='resolved-creds')
+        sentinel_creds.name = 'defaulted-user@EXAMPLE.COM'
+        mock_credentials.return_value = sentinel_creds
+
+        hyperv = self._make_hyperv()
+        s = hyperv.connect()
+
+        mock_credentials.assert_called_once_with(name=None, store=None, usage='initiate')
+        self.assertIs(s.auth.creds, sentinel_creds)
+
+    @patch('virtwho.virt.hyperv.hyperv.gssapi.Credentials')
+    @patch('requests.Session')
+    def test_kerberos_connect_runs_oneshot(self, session, mock_credentials):
+        """Kerberos auth path can complete a full oneshot run with mocked responses."""
+        session.return_value.post.side_effect = HyperVMock.post
+        hyperv = self._make_hyperv()
+        hyperv._oneshot = True
+        hyperv.dest = Queue()
+        hyperv._terminate_event = Event()
+        hyperv._interval = 0
+        hyperv._run()
+
+        session.return_value.post.assert_called()
+
+    @patch('virtwho.virt.hyperv.hyperv.gssapi.Credentials')
+    @patch('requests.Session')
+    def test_kerberos_401_raises_auth_failed(self, session, mock_credentials):
+        """A 401 after kerberos negotiate raises HyperVAuthFailed."""
+        session.return_value.post.return_value.status_code = 401
+        hyperv = self._make_hyperv()
+        hyperv._oneshot = True
+        hyperv.dest = Queue()
+        hyperv._terminate_event = Event()
+        hyperv._interval = 0
+        self.assertRaises(VirtError, hyperv._run)

--- a/virt-who.spec
+++ b/virt-who.spec
@@ -19,6 +19,8 @@ Requires:       python3-libvirt
 Requires:       python3-subscription-manager-rhsm > 1.25.6
 Requires:       python3-cryptography
 Requires:       python3-requests
+# requests-gssapi required for Hyper-V Kerberos authentication support
+Requires:       python3-requests-gssapi
 Requires:       python3-pyyaml
 
 Requires: python3-systemd

--- a/virtwho/virt/hyperv/hyperv.py
+++ b/virtwho/virt/hyperv/hyperv.py
@@ -27,7 +27,7 @@ from requests.auth import AuthBase
 import requests
 
 from virtwho import virt
-from virtwho.config import VirtConfigSection
+from virtwho.config import VirtConfigSection, accessible_file
 
 try:
     from uuid import uuid1
@@ -48,12 +48,92 @@ class HypervConfigSection(VirtConfigSection):
 
     VIRT_TYPE = 'hyperv'
     HYPERVISOR_ID = ('uuid', 'hostname')
+    AUTH_METHODS = ('basic', 'kerberos')
 
     def __init__(self, section_name, wrapper, *args, **kwargs):
         super(HypervConfigSection, self).__init__(section_name, wrapper, *args, **kwargs)
         self.add_key('server', validation_method=self._validate_server, required=True)
         self.add_key('username', validation_method=self._validate_username, required=True)
         self.add_key('password', validation_method=self._validate_unencrypted_password, required=True)
+        self.add_key('auth_method', validation_method=self._validate_auth_method, default='basic')
+        self.add_key('kerberos_keytab', validation_method=self._validate_kerberos_keytab)
+        self.add_key('kerberos_principal', validation_method=self._validate_kerberos_principal)
+
+    def _validate_auth_method(self, key):
+        if key not in self._values:
+            return None
+        value = self._values[key]
+        result = None
+        if value not in self.AUTH_METHODS:
+            result = (
+                'error',
+                'Invalid auth_method "%s": must be one of: %s' % (value, ', '.join(self.AUTH_METHODS))
+            )
+        return result
+
+    def _validate_kerberos_keytab(self, key):
+        if key not in self._values:
+            return None
+        value = self._values[key]
+        result = None
+        auth_method = self._values.get('auth_method', self.defaults.get('auth_method', 'basic'))
+        if auth_method != 'kerberos':
+            result = (
+                'warning',
+                'Option "%s" is only applicable when auth_method=kerberos, ignoring' % key
+            )
+            del self._values[key]
+            return result
+        try:
+            accessible_file(value)
+        except ValueError as e:
+            result = (
+                'error',
+                'Invalid kerberos_keytab: %s' % str(e)
+            )
+        return result
+
+    def _validate_kerberos_principal(self, key):
+        if key not in self._values:
+            return None
+        value = self._values[key]
+        result = None
+        auth_method = self._values.get('auth_method', self.defaults.get('auth_method', 'basic'))
+        if auth_method != 'kerberos':
+            result = (
+                'warning',
+                'Option "%s" is only applicable when auth_method=kerberos, ignoring' % key
+            )
+            del self._values[key]
+            return result
+        if not isinstance(value, str) or len(value) == 0:
+            result = (
+                'error',
+                'Option "%s" must be a non-empty string' % key
+            )
+        return result
+
+    def _pre_validate(self):
+        auth_method = self._values.get('auth_method', self.defaults.get('auth_method', 'basic'))
+        if auth_method == 'kerberos':
+            self._required_keys.discard('password')
+            self._required_keys.discard('username')
+        super(HypervConfigSection, self)._pre_validate()
+
+    def _post_validate(self):
+        auth_method = self._values.get('auth_method', self.defaults.get('auth_method', 'basic'))
+        if auth_method == 'kerberos':
+            if 'username' in self._values and self._values['username']:
+                self.validation_messages.append((
+                    'warning',
+                    'Username is ignored when auth_method=kerberos'
+                ))
+            if 'password' in self._values and self._values['password']:
+                self.validation_messages.append((
+                    'warning',
+                    'Password is ignored when auth_method=kerberos'
+                ))
+        super(HypervConfigSection, self)._post_validate()
 
     def _validate_server(self, key):
         error = super(HypervConfigSection, self)._validate_server(key)

--- a/virtwho/virt/hyperv/hyperv.py
+++ b/virtwho/virt/hyperv/hyperv.py
@@ -25,6 +25,9 @@ import base64
 from xml.etree import ElementTree
 from requests.auth import AuthBase
 import requests
+import gssapi
+from requests_gssapi import HTTPSPNEGOAuth, OPTIONAL
+from requests_gssapi.exceptions import SPNEGOExchangeError, MutualAuthenticationError
 
 from virtwho import virt
 from virtwho.config import VirtConfigSection, accessible_file
@@ -353,6 +356,12 @@ class HyperVSoap(object):
         }
         try:
             response = self.connection.post(self.url, body, headers=headers)
+        except (SPNEGOExchangeError, MutualAuthenticationError) as e:
+            raise HyperVAuthFailed(
+                "Kerberos authentication failed: %s. "
+                "Verify that the keytab and principal are correct, "
+                "and that the KDC is reachable." % str(e)
+            )
         except requests.RequestException as e:
             raise HyperVException("Unable to connect to Hyper-V server: %s" % str(e))
 
@@ -492,8 +501,11 @@ class HyperV(virt.Virt):
                                      oneshot=oneshot,
                                      status=status)
         self.url = self.config['url']
-        self.username = self.config['username']
-        self.password = self.config['password']
+        self.auth_method = self.config.get('auth_method', 'basic')
+        self.username = self.config.get('username', '')
+        self.password = self.config.get('password', '')
+        self.kerberos_keytab = self.config.get('kerberos_keytab', None)
+        self.kerberos_principal = self.config.get('kerberos_principal', None)
 
         # First try to use old API (root/virtualization namespace) if doesn't
         # work, go with root/virtualization/v2
@@ -504,7 +516,34 @@ class HyperV(virt.Virt):
         s = requests.Session()
         adapter = requests.adapters.HTTPAdapter(pool_connections=1, pool_maxsize=1)
         s.mount('http://', adapter)
-        s.auth = HyperVAuth(self.username, self.password, self.logger)
+
+        if self.auth_method == 'kerberos':
+            self.logger.debug('Using Kerberos (SPNEGO/Negotiate) authentication')
+            name = None
+            store = None
+
+            if self.kerberos_keytab:
+                store = {"client_keytab": f"FILE:{self.kerberos_keytab}"}
+                self.logger.debug('Using Kerberos keytab: %s', self.kerberos_keytab)
+
+            if self.kerberos_principal:
+                name = gssapi.Name(self.kerberos_principal, name_type=gssapi.NameType.kerberos_principal)
+                self.logger.debug('Using Kerberos principal: %s', self.kerberos_principal)
+
+            try:
+                # If 'name' is omitted, python-gssapi pulls the default principal from the 'store' (keytab)
+                # or the default credential cache. If 'store' is omitted, it looks in the default cache.
+                creds = gssapi.Credentials(name=name, store=store, usage="initiate")
+            except gssapi.exceptions.GSSError as e:
+                raise HyperVException(f"Failed to acquire Kerberos credentials: {e}")
+
+            if name is None:
+                self.logger.debug('Resolved default Kerberos principal: %s', creds.name)
+
+            s.auth = HTTPSPNEGOAuth(creds=creds, mutual_authentication=OPTIONAL)
+        else:
+            self.logger.debug('Using Basic authentication')
+            s.auth = HyperVAuth(self.username, self.password, self.logger)
         return s
 
     @classmethod


### PR DESCRIPTION
## Summary
Adds Kerberos (SPNEGO/Negotiate) authentication as an alternative to Basic auth when virt-who connects to a Hyper-V server.

Resolves: CCT-2189
Resolves: CCT-2188

## Changes
### Config (HypervConfigSection)
- New `auth_method` option (`basic` | `kerberos`, default `basic`).
- New `kerberos_keytab` option — optional path to a keytab file; validated to exist and be readable.
- New `kerberos_principal` option — optional Kerberos principal string.
- When auth_method=basic (default), behavior is unchanged: username/password remain required.
- When auth_method=kerberos:
    - username/password become optional; if supplied anyway, a warning is logged and they're ignored.
    - kerberos_keytab/kerberos_principal are only valid in this mode — setting them under basic logs a warning and drops the value.
- Invalid auth_method values raise a validation error.

### Connection logic (HyperV)
- When auth_method=kerberos, builds gssapi.Credentials from the optional keytab/principal (falling back to the default credential cache/principal if omitted) and authenticates requests with HTTPSPNEGOAuth (via requests-gssapi).
- Failures acquiring credentials or completing the SPNEGO exchange are surfaced as HyperVException/HyperVAuthFailed exceptions
- auth_method=basic continues to use the existing HyperVAuth.

### Tests
- tests/test_config_section_hyperv.py (new, 243 lines): coverage for the new config keys, defaults, validation errors/warnings, and interaction between auth_method and username/password/keytab/principal.
- tests/test_hyperv.py: extended with tests for Kerberos credential acquisition, SPNEGO auth wiring, and error handling paths.

### Dependencies
- Adds hard dependency on `python3-requests-gssapi`